### PR TITLE
Added more properties to TOC entries

### DIFF
--- a/src/Generator/JsonGenerator.php
+++ b/src/Generator/JsonGenerator.php
@@ -89,6 +89,8 @@ class JsonGenerator
         foreach ($titles as $title) {
             $tocTree[] = [
                 'url' => sprintf('%s#%s', $metaEntry->getUrl(), Environment::slugify($title[0])),
+                'page' => u($metaEntry->getUrl())->beforeLast('.html'),
+                'fragment' => Environment::slugify($title[0]),
                 'title' => $title[0],
                 'children' => $this->generateToc($metaEntry, $title[1]),
             ];


### PR DESCRIPTION
The original TOC entry URL has something like `"url" => "dashboards.html#dashboard-route"` ... but I need each part of the URL separately because we're generating URLs with Twig's `path()` inside a Symfony app.

This PR adds the following properties to allow generating URLs with them:

```php
    "page" => "dashboards"
    "fragment" => "dashboard-route"
```