### PR TITLE
Add PHP 8 compatibility for optional arguments

### DIFF
--- a/src/DocsKernel.php
+++ b/src/DocsKernel.php
@@ -23,7 +23,7 @@ class DocsKernel extends Kernel
 {
     private $buildContext;
 
-    public function __construct(?Configuration $configuration = null, $directives = [], $references = [], BuildContext $buildContext)
+    public function __construct(BuildContext $buildContext, ?Configuration $configuration = null, $directives = [], $references = [])
     {
         parent::__construct($configuration, $directives, $references);
 

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -56,10 +56,10 @@ final class KernelFactory
         $twig->addExtension(new AssetsExtension());
 
         return new DocsKernel(
+            $buildContext,
             $configuration,
             self::getDirectives(),
-            self::getReferences($buildContext),
-            $buildContext
+            self::getReferences($buildContext)
         );
     }
 


### PR DESCRIPTION
PHP 8 doesn't like required arguments defined after optional arguments, so let's swap the order of these arguments.