### PR TITLE
Changed a bit the way PHP code is highlighted

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -74,6 +74,9 @@ class CodeNodeRenderer implements NodeRenderer
         if ('text' !== $language) {
             $highLighter = new Highlighter();
             $code = $highLighter->highlight(self::LANGUAGES_MAPPING[$language] ?? $language, $code)->value;
+
+            // this allows to highlight the $ in PHP variable names
+            $code = str_replace('<span class="hljs-variable">$', '<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>', $code);
         }
 
         return $this->templateRenderer->render(

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -27,7 +27,7 @@
 </span>
                                     {
                                     <span class="hljs-comment">/** * <span class="hljs-doctag">@Assert</span>\Iban( * message="This is not a valid International Bank Account Number (IBAN)." * ) */</span>
-                                    <span class="hljs-keyword">protected</span> <span class="hljs-variable">$bankAccountNumber</span>;
+                                    <span class="hljs-keyword">protected</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>bankAccountNumber</span>;
 }
                                 </pre>
                     </div>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -26,9 +26,9 @@
 <span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>; <span class="hljs-keyword">return</span>
                                     <span class="hljs-function">
                                         <span class="hljs-keyword">function</span>
-                                        <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable">$routes</span>)</span>
+                                        <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span>
                                     </span>
-                                    { <span class="hljs-variable">$routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
+                                    { <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
 };</pre>
                     </div>
                 </td>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -25,7 +25,7 @@
                         <pre class="hljs php">
                                     <span class="hljs-comment">// config/routes.php</span>
 <span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>; <span class="hljs-keyword">return</span>
-                                    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable">$routes</span>)</span> </span>
+                                    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>
                                     { <span class="hljs-variable">$routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
 };</pre>
                     </div>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -26,7 +26,10 @@
                                     <span class="hljs-comment">// config/routes.php</span>
 <span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>; <span class="hljs-keyword">return</span>
                                     <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>
-                                    { <span class="hljs-variable">$routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
+                                    {                                    <span class="hljs-variable">
+                                        <span class="hljs-variable-other-marker">$</span>
+                                        routes
+                                    </span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
 };</pre>
                     </div>
                 </td>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -140,7 +140,10 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
                                                         \
                                                         <span class="hljs-title">DateTimeType</span>
                                                         ; 
-                                                        <span class="hljs-variable">$builder</span>
+                                                        <span class="hljs-variable">
+                                                            <span class="hljs-variable-other-marker">$</span>
+                                                            builder
+                                                        </span>
                                                         <span class="hljs-operator">-&gt;</span>
                                                         add(
                                                         <span class="hljs-string">'startDateTime'</span>
@@ -397,7 +400,10 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
                                         <div class="highlight">
                                             <pre class="hljs php">
                                                                     <span class="hljs-comment">// app/config/config.php</span>
-                                                                    <span class="hljs-variable">$container</span>
+                                                                    <span class="hljs-variable">
+                                                                        <span class="hljs-variable-other-marker">$</span>
+                                                                        container
+                                                                    </span>
                                                                     <span class="hljs-operator">-&gt;</span>
                                                                     loadFromExtension(
                                                                     <span class="hljs-string">'framework'</span>


### PR DESCRIPTION
This is an example of the endless possibilities that having a PHP-based docs builder brings to us. We can easily change or update anything.

For example, I want to highlight code in the same way that GitHub does ... which requires showing a different color for the `$` of the PHP variable names. The current highlighter doesn't support that:

![image](https://user-images.githubusercontent.com/73419/109706290-0cce6e00-7b99-11eb-9287-cd810bc2ae6b.png)

But thanks to this super simple change, it works now:

![image](https://user-images.githubusercontent.com/73419/109706322-16f06c80-7b99-11eb-9b29-18be122050ad.png)
