### PR TITLE
Updated the header permalinks

### DIFF
--- a/src/Templates/default/html/header-title.html.twig
+++ b/src/Templates/default/html/header-title.html.twig
@@ -1,1 +1,1 @@
-<h{{ titleNode.level }}>{{ titleNode.value.render()|raw }}<a class="headerlink" href="#{{ titleNode.id }}" title="Permalink to this headline">¶</a></h{{ titleNode.level }}>
+<h{{ titleNode.level }} id="{{ titleNode.id }}"><a class="headerlink" href="#{{ titleNode.id }}" title="Permalink to this headline">{{ titleNode.value.render()|raw }}</a></h{{ titleNode.level }}>


### PR DESCRIPTION
Making the entire headline a clickable link is easier for readers. Also, the marker (`¶`) is now added via CSS `::before` pseudo-selector, which allows us to change its design more easily when needed.