### PR TITLE
Add all the missing RST admonitions

### DIFF
--- a/src/Directive/AttentionDirective.php
+++ b/src/Directive/AttentionDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Directive;
+
+class AttentionDirective extends AbstractAdmonitionDirective
+{
+    public function __construct()
+    {
+        parent::__construct('attention', 'Attention');
+    }
+}

--- a/src/Directive/DangerDirective.php
+++ b/src/Directive/DangerDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Directive;
+
+class DangerDirective extends AbstractAdmonitionDirective
+{
+    public function __construct()
+    {
+        parent::__construct('danger', 'Danger');
+    }
+}

--- a/src/Directive/ErrorDirective.php
+++ b/src/Directive/ErrorDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Directive;
+
+class ErrorDirective extends AbstractAdmonitionDirective
+{
+    public function __construct()
+    {
+        parent::__construct('error', 'Error');
+    }
+}

--- a/src/Directive/HintDirective.php
+++ b/src/Directive/HintDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Directive;
+
+class HintDirective extends AbstractAdmonitionDirective
+{
+    public function __construct()
+    {
+        parent::__construct('hint', 'Hint');
+    }
+}

--- a/src/Directive/ImportantDirective.php
+++ b/src/Directive/ImportantDirective.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Docs Builder package.
+ * (c) Ryan Weaver <ryan@symfonycasts.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyDocsBuilder\Directive;
+
+class ImportantDirective extends AbstractAdmonitionDirective
+{
+    public function __construct()
+    {
+        parent::__construct('important', 'Important');
+    }
+}

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -68,10 +68,15 @@ final class KernelFactory
     {
         return [
             new SymfonyDirectives\AdmonitionDirective(),
+            new SymfonyDirectives\AttentionDirective(),
             new SymfonyDirectives\CautionDirective(),
             new SymfonyDirectives\CodeBlockDirective(),
             new SymfonyDirectives\ConfigurationBlockDirective(),
+            new SymfonyDirectives\DangerDirective(),
             new SymfonyDirectives\DeprecatedDirective(),
+            new SymfonyDirectives\ErrorDirective(),
+            new SymfonyDirectives\HintDirective(),
+            new SymfonyDirectives\ImportantDirective(),
             new SymfonyDirectives\IndexDirective(),
             new SymfonyDirectives\RoleDirective(),
             new SymfonyDirectives\NoteDirective(),


### PR DESCRIPTION
While reviewing the parsing of SonataAdmin docs, I saw that they use `.. important::` directive. I thought it was a mistake ... but I was the wrong one, because I didn't know that RST defines many admonitions besides the `note`, `tip`, `caution` and `warning` that we use in Symfony Docs. See https://docutils.sourceforge.io/docs/ref/rst/directives.html#specific-admonitions

So, given that adding them is trivial, I think we should add all of them. Do you agree?