### PR TITLE
Updated Twig code highlighter

### DIFF
--- a/src/Templates/highlight.php/twig.json
+++ b/src/Templates/highlight.php/twig.json
@@ -28,13 +28,13 @@
                 {
                     "className": "name",
                     "begin": "\\w+",
-                    "keywords": "autoescape block do embed extends filter flush for if import include macro sandbox set spaceless use verbatim endautoescape endblock enddo endembed endextends endfilter endflush endfor endif endimport endinclude endmacro endsandbox endset endspaceless enduse endverbatim",
+                    "keywords": "apply autoescape block deprecated do embed extends filter flush for from if import include macro sandbox set use verbatim with endapply endautoescape endblock enddeprecated enddo endembed endextends endfilter endflush endfor endfrom endif endimport endinclude endmacro endsandbox endset enduse endverbatim endwith",
                     "starts": {
                         "endsWithParent": true,
                         "contains": [
                             {
                                 "begin": "\\|[A-Za-z_]+:?",
-                                "keywords": "abs batch capitalize convert_encoding date date_modify default escape first format join json_encode keys last length lower merge nl2br number_format raw replace reverse round slice sort split striptags title trim upper url_encode",
+                                "keywords": "abs batch capitalize column convert_encoding date date_modify default escape filter first format inky_to_html inline_css join json_encode keys last length lower map markdown merge nl2br number_format raw reduce replace reverse round slice sort spaceless split striptags title trim upper url_encode",
                                 "contains": [
                                     {
                                         "beginKeywords": "attribute block constant cycle date dump include max min parent random range source template_from_string",


### PR DESCRIPTION
Updated to the latest version of the highlight.php repository.

I haven't updated the PHP on purpose because the latest version of the highlighter removes features such as highlighting PHP variables 😢 