### PR TITLE
Update the generated code for admonitions

### DIFF
--- a/src/Directive/AbstractAdmonitionDirective.php
+++ b/src/Directive/AbstractAdmonitionDirective.php
@@ -38,7 +38,7 @@ abstract class AbstractAdmonitionDirective extends SubDirective
             ]
         );
 
-        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div></div>');
+        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div>');
     }
 
     final public function getName(): string

--- a/src/Directive/AdmonitionDirective.php
+++ b/src/Directive/AdmonitionDirective.php
@@ -28,7 +28,7 @@ class AdmonitionDirective extends SubDirective
             ]
         );
 
-        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div></div>');
+        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div>');
     }
 
     public function getName(): string

--- a/src/Templates/default/html/directives/admonition.html.twig
+++ b/src/Templates/default/html/directives/admonition.html.twig
@@ -1,3 +1,2 @@
-<div class="admonition-wrapper{{ class ? (' '~class) : '' }}">
-    <div class="admonition admonition-{{ name }}">
-        <p class="admonition-title">{{ text }}</p>
+<div class="admonition admonition-{{ name }} {{ class ?? '' }}">
+    <p class="admonition-title">{{ text }}</p>


### PR DESCRIPTION
Originally this parser generated the exact same HTML as the symfony.com parser. This was done on purpose to allow a seamless integration of the new parser. However, that's not important anymore because the new parser is going to be used in a new symfony.com section ... and then, hopefully, in the entire symfony.com website but updating the styles too.