### PR TITLE
Add icons to admonitions

### DIFF
--- a/src/Templates/default/html/directives/admonition.html.twig
+++ b/src/Templates/default/html/directives/admonition.html.twig
@@ -1,3 +1,14 @@
-<div class="admonition-wrapper{{ class ? (' '~class) : '' }}">
-    <div class="admonition admonition-{{ name }}">
-        <p class="admonition-title">{{ text }}</p>
+{# icons are from https://heroicons.com/ - MIT License #}
+<div class="admonition admonition-{{ name }} {{ class ?? '' }}">
+    <p class="admonition-title">
+        {% if name in ['admonition', 'note'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+        {% elseif name in ['hint', 'tip'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
+        {% elseif name in ['attention', 'important', 'warning'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+        {% elseif name in ['caution', 'danger', 'error'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        {% endif %}
+        {{ text }}
+    </p>


### PR DESCRIPTION
I'd prefer to not add these as SVG files and add them dynamically via CSS background. However, SVGs as CSS background images have lots of problems. Even `currentColor` doesn't work as stroke color (unless you do very ugly hacks).

So, let's add them as embedded files ... and if sometime we want to remove them, we can always hide them using CSS before removing them for real.