### PR TITLE
[tests] fix missing loc-x class in literal-blocks

### DIFF
--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-bash">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-2">
     <div class="highlight-html+php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-html+twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-html">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-ini">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-2">
     <div class="highlight-php-annotations">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-terminal">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-text">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/xml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/xml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-xml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/yaml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/yaml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div class="literal-block">
+<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div class="literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>
@@ -21,7 +21,7 @@
             </tr>
         </table>
     </div>
-</div></li><li><em>PHP</em><div class="literal-block">
+</div></li><li><em>PHP</em><div class="literal-block loc-1">
                 <div class="highlight-php">
                     <table class="highlighttable">
                         <tr>

--- a/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
@@ -8,7 +8,7 @@
     <div class="admonition admonition-note">
         <p class="admonition-title">Note</p>
         <p>test</p>
-        <div class="literal-block">
+        <div class="literal-block loc-1">
             <div class="highlight-php">
                 <table class="highlighttable">
                     <tr>

--- a/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
@@ -8,7 +8,7 @@
     <div class="admonition admonition-sidebar">
         <p class="sidebar-title">The sidebar's title</p>
         <p>some text before code block</p>
-        <div class="literal-block">
+        <div class="literal-block loc-1">
             <div class="highlight-php">
                 <table class="highlighttable">
                     <tr>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <p>here is some php code from literal:</p>
-<div class="literal-block">
+<div class="literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>


### PR DESCRIPTION
adds respective `loc-X` class to `literal-blocks` in expected fixtures