### PR TITLE
Add support for <code> in headings

### DIFF
--- a/tests/fixtures/expected/main/index.html
+++ b/tests/fixtures/expected/main/index.html
@@ -22,7 +22,7 @@
     </div>
 <span id="reference-forms-type-date-format"></span>
 <div class="section" id="a-header">
-    <h2>A header<a class="headerlink" href="#a-header" title="Permalink to this headline">¶</a></h2>
+    <h2>A header with <code>a code literal</code><a class="headerlink" href="#a-header" title="Permalink to this headline">¶</a></h2>
     <p>Some info...</p>
 </div>
 </div>

--- a/tests/fixtures/source/main/index.rst
+++ b/tests/fixtures/source/main/index.rst
@@ -10,7 +10,7 @@ Some Test Docs!
 
 .. _reference-forms-type-date-format:
 
-A header
---------
+A header with ``a code literal``
+--------------------------------
 
 Some info...


### PR DESCRIPTION
This adds a failing test for #45 in case it's useful for the developer who tries to fix this. Thanks!