### PR TITLE
Don't add unnecessary HTML fragments in TOC links

### DIFF
--- a/tests/fixtures/source/toctree/directory/another_file.rst
+++ b/tests/fixtures/source/toctree/directory/another_file.rst
@@ -1,2 +1,8 @@
 Another file
 ============
+
+Some text.
+
+.. _some_reference:
+
+And more text.

--- a/tests/fixtures/source/toctree/index.rst
+++ b/tests/fixtures/source/toctree/index.rst
@@ -15,6 +15,11 @@ Toctree
     directory/another_file
 
 .. toctree::
+
+    file
+    :ref:`Some specific reference <some_reference>`
+
+.. toctree::
     :glob:
 
     *


### PR DESCRIPTION
This is a failing test for #42.

When linking to a file, we shouldn't add the HTML fragment with the `id` of the first article section. It's redundant and causes some issues in browsers when loading the page.

I can't work on fixing this right now, but this failing test will hopefully help others fix it. Thanks!