### PR TITLE
only run push tests on master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,8 @@ name: Docs Builder Tests
 
 on:
     push:
-#        branches:
-#            - master
+        branches:
+            - master
     pull_request:
     release:
 


### PR DESCRIPTION
Prevents duplicate CI runs on pull requests while allowing CI to run anytime a direct push to the `master` branch is performed.