### PR TITLE
Mark code elements as non-translatable

### DIFF
--- a/src/Templates/default/html/code.html.twig
+++ b/src/Templates/default/html/code.html.twig
@@ -1,4 +1,4 @@
-<div class="literal-block loc-{{ numLocDigits }}">
+<div translate="no" class="literal-block loc-{{ numLocDigits }}">
     <div class="highlight-{{ language }}">
         <table class="highlighttable">
             <tr>

--- a/src/Templates/default/html/code.html.twig
+++ b/src/Templates/default/html/code.html.twig
@@ -1,4 +1,4 @@
-<div translate="no" class="literal-block loc-{{ numLocDigits }}">
+<div translate="no" class="notranslate literal-block loc-{{ numLocDigits }}">
     <div class="highlight-{{ language }}">
         <table class="highlighttable">
             <tr>

--- a/src/Templates/default/html/literal.html.twig
+++ b/src/Templates/default/html/literal.html.twig
@@ -1,1 +1,1 @@
-<code>{{ text|raw }}</code>
+<code translate="no">{{ text|raw }}</code>

--- a/src/Templates/default/html/literal.html.twig
+++ b/src/Templates/default/html/literal.html.twig
@@ -1,1 +1,1 @@
-<code translate="no">{{ text|raw }}</code>
+<code translate="no" class="notranslate">{{ text|raw }}</code>

--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-bash">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-bash">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-2">
+<div translate="no" class="notranslate literal-block loc-2">
     <div class="highlight-html+php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-2">
+<div translate="no" class="literal-block loc-2">
     <div class="highlight-html+php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-html+twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-html+twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-html">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/html.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-html">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-ini">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-ini">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-2">
+<div translate="no" class="notranslate literal-block loc-2">
     <div class="highlight-php-annotations">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-2">
+<div translate="no" class="literal-block loc-2">
     <div class="highlight-php-annotations">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-terminal">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-terminal">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-text">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-text">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-twig">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/xml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/xml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-xml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/xml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/xml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-xml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/yaml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/yaml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/code-blocks/yaml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/yaml.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div class="literal-block loc-1">
+<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div translate="no" class="literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>
@@ -21,7 +21,7 @@
             </tr>
         </table>
     </div>
-</div></li><li><em>PHP</em><div class="literal-block loc-1">
+</div></li><li><em>PHP</em><div translate="no" class="literal-block loc-1">
                 <div class="highlight-php">
                     <table class="highlighttable">
                         <tr>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
 </head>
 <body>
-<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div translate="no" class="literal-block loc-1">
+<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-yaml">
         <table class="highlighttable">
             <tr>
@@ -21,7 +21,7 @@
             </tr>
         </table>
     </div>
-</div></li><li><em>PHP</em><div translate="no" class="literal-block loc-1">
+</div></li><li><em>PHP</em><div translate="no" class="notranslate literal-block loc-1">
                 <div class="highlight-php">
                     <table class="highlighttable">
                         <tr>

--- a/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
@@ -12,7 +12,7 @@
         Note
     </p>
     <p>test</p>
-    <div translate="no" class="literal-block loc-1">
+    <div translate="no" class="notranslate literal-block loc-1">
         <div class="highlight-php">
             <table class="highlighttable">
                 <tr>

--- a/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
@@ -12,7 +12,7 @@
         Note
     </p>
     <p>test</p>
-    <div class="literal-block loc-1">
+    <div translate="no" class="literal-block loc-1">
         <div class="highlight-php">
             <table class="highlighttable">
                 <tr>

--- a/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
@@ -8,7 +8,7 @@
     <div class="admonition admonition-sidebar">
         <p class="sidebar-title">The sidebar's title</p>
         <p>some text before code block</p>
-        <div translate="no" class="literal-block loc-1">
+        <div translate="no" class="notranslate literal-block loc-1">
             <div class="highlight-php">
                 <table class="highlighttable">
                     <tr>

--- a/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
@@ -8,7 +8,7 @@
     <div class="admonition admonition-sidebar">
         <p class="sidebar-title">The sidebar's title</p>
         <p>some text before code block</p>
-        <div class="literal-block loc-1">
+        <div translate="no" class="literal-block loc-1">
             <div class="highlight-php">
                 <table class="highlighttable">
                     <tr>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <p>here is some php code from literal:</p>
-<div translate="no" class="literal-block loc-1">
+<div translate="no" class="notranslate literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <p>here is some php code from literal:</p>
-<div class="literal-block loc-1">
+<div translate="no" class="literal-block loc-1">
     <div class="highlight-php">
         <table class="highlighttable">
             <tr>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -9,12 +9,12 @@
         <a class="headerlink" href="#datetimetype-field" title="Permalink to this headline">DateTimeType Field</a>
     </h1>
     <p>This field type allows the user to modify data that represents a specific
-date and time (e.g. <code>1984-06-05 12:15:30</code>).</p>
+date and time (e.g. <code translate="no">1984-06-05 12:15:30</code>).</p>
     <table>
         <tbody>
         <tr>
             <td>Underlying Data Type</td>
-            <td>can be <code>DateTime</code>, string, timestamp, or array (see the <code>input</code> option)</td>
+            <td>can be <code translate="no">DateTime</code>, string, timestamp, or array (see the <code translate="no">input</code> option)</td>
         </tr>
         <tr>
             <td>Rendered as</td>
@@ -63,8 +63,8 @@ date and time (e.g. <code>1984-06-05 12:15:30</code>).</p>
             <h3 id="the-date-format-option">
                 <a class="headerlink" href="#the-date-format-option" title="Permalink to this headline">The date_format Option</a>
             </h3>
-            <p><strong>type</strong>: <code>integer</code> or <code>string</code><strong>default</strong>: <code>IntlDateFormatter::MEDIUM</code></p>
-            <p>Defines the <code>format</code> option that will be passed down to the date field.
+            <p><strong>type</strong>: <code translate="no">integer</code> or <code translate="no">string</code><strong>default</strong>: <code translate="no">IntlDateFormatter::MEDIUM</code></p>
+            <p>Defines the <code translate="no">format</code> option that will be passed down to the date field.
 for more details.</p>
             <div class="admonition admonition-tip ">
                 <p class="admonition-title">
@@ -95,7 +95,7 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
                 <p>Sometimes we add notes. But not too often because they interrupt the flow.
 <a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
             </div>
-            <p>This is included documentation about the <code>date_widget</code> option.</p>
+            <p>This is included documentation about the <code translate="no">date_widget</code> option.</p>
         </div>
         <div class="section">
             <h3 id="placeholder">
@@ -104,16 +104,16 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
             <div class="versionadded">
                 <div>
                     <span class="versionmodified">New in version 2.6: </span>
-                    <p>The <code>placeholder</code> option was introduced in Symfony 2.6 and replaces
-<code>empty_value</code>, which is available prior to 2.6.
+                    <p>The <code translate="no">placeholder</code> option was introduced in Symfony 2.6 and replaces
+<code translate="no">empty_value</code>, which is available prior to 2.6.
 <a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
                 </div>
             </div>
-            <p><strong>type</strong>: <code>string</code> | <code>array</code></p>
-            <p>If your widget option is set to <code>choice</code>, then this field will be represented
-as a series of <code>select</code> boxes. When the placeholder value is a string,
+            <p><strong>type</strong>: <code translate="no">string</code> | <code translate="no">array</code></p>
+            <p>If your widget option is set to <code translate="no">choice</code>, then this field will be represented
+as a series of <code translate="no">select</code> boxes. When the placeholder value is a string,
 it will be used as the <strong>blank value</strong> of all select boxes:</p>
-            <div class="literal-block loc-1">
+            <div translate="no" class="literal-block loc-1">
                 <div class="highlight-php">
                     <table class="highlighttable">
                         <tr>
@@ -168,11 +168,11 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
             </div>
             <p>Custom classes for links are also cool:</p>
             <ul class="list-config-options">
-                <li><code>excluded_ajax_paths</code></li>
-                <li><code>intercept_redirects</code></li>
-                <li><code>position</code></li>
-                <li><code>toolbar</code></li>
-                <li><code>verbose</code></li>
+                <li><code translate="no">excluded_ajax_paths</code></li>
+                <li><code translate="no">intercept_redirects</code></li>
+                <li><code translate="no">position</code></li>
+                <li><code translate="no">toolbar</code></li>
+                <li><code translate="no">verbose</code></li>
                 <li><a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></li>
             </ul>
         </div>
@@ -180,8 +180,8 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
             <h3 id="format">
                 <a class="headerlink" href="#format" title="Permalink to this headline">format</a>
             </h3>
-            <p><strong>type</strong>: <code>string</code><strong>default</strong>: <code>Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
-            <p>If the <code>widget</code> option is set to <code>single_text</code>, this option specifies
+            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
+            <p>If the <code translate="no">widget</code> option is set to <code translate="no">single_text</code>, this option specifies
 the format of the input, i.e. how Symfony will interpret the given input
 as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax" class="reference external">Date/Time Format Syntax</a>.</p>
             <div class="admonition-wrapper">
@@ -208,16 +208,16 @@ as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/
             <h3 id="time-widget">
                 <a class="headerlink" href="#time-widget" title="Permalink to this headline">time_widget</a>
             </h3>
-            <p><strong>type</strong>: <code>string</code><strong>default</strong>: <code>choice</code></p>
-            <p>Defines the <code>widget</code> option for the <code>TimeType</code>.</p>
+            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">choice</code></p>
+            <p>Defines the <code translate="no">widget</code> option for the <code translate="no">TimeType</code>.</p>
         </div>
         <div class="section">
             <h3 id="widget">
                 <a class="headerlink" href="#widget" title="Permalink to this headline">widget</a>
             </h3>
-            <p><strong>type</strong>: <code>string</code><strong>default</strong>: <code>null</code></p>
-            <p>Defines the <code>widget</code> option for both the <code>DateType</code>.
-and <code>TimeType</code>. This can be overridden
+            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">null</code></p>
+            <p>Defines the <code translate="no">widget</code> option for both the <code translate="no">DateType</code>.
+and <code translate="no">TimeType</code>. This can be overridden
 with the <a href="datetime.html#date-widget" class="reference internal">date_widget</a> and <a href="datetime.html#time-widget" class="reference internal">time_widget</a> options.</p>
         </div>
     </div>
@@ -230,16 +230,16 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
         <h3 id="by-reference">
             <a class="headerlink" href="#by-reference" title="Permalink to this headline">by_reference</a>
         </h3>
-        <p><strong>default</strong>: <code>false</code></p>
-        <p>The <code>DateTime</code> classes are treated as immutable objects.</p>
+        <p><strong>default</strong>: <code translate="no">false</code></p>
+        <p>The <code translate="no">DateTime</code> classes are treated as immutable objects.</p>
     </div>
     <div class="section">
         <h3 id="error-bubbling">
             <a class="headerlink" href="#error-bubbling" title="Permalink to this headline">error_bubbling</a>
         </h3>
-        <p><strong>default</strong>: <code>false</code></p>
+        <p><strong>default</strong>: <code translate="no">false</code></p>
         <p>We also support code blocks!</p>
-        <div class="literal-block loc-1">
+        <div translate="no" class="literal-block loc-1">
             <div class="highlight-yaml">
                 <table class="highlighttable">
                     <tr>
@@ -267,7 +267,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
             <ul class="simple">
                 <li>
                     <em>YAML</em>
-                    <div class="literal-block loc-1">
+                    <div translate="no" class="literal-block loc-1">
                         <div class="highlight-yaml">
                             <table class="highlighttable">
                                 <tr>
@@ -300,7 +300,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
                 </li>
                 <li>
                     <em>XML</em>
-                    <div class="literal-block loc-2">
+                    <div translate="no" class="literal-block loc-2">
                         <div class="highlight-xml">
                             <table class="highlighttable">
                                 <tr>
@@ -383,7 +383,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
                 </li>
                 <li>
                     <em>PHP</em>
-                    <div class="literal-block loc-2">
+                    <div translate="no" class="literal-block loc-2">
                         <div class="highlight-php">
                             <table class="highlighttable">
                                 <tr>
@@ -446,12 +446,12 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
         <tbody>
         <tr>
             <td>widget</td>
-            <td><code>mixed</code></td>
-            <td>The value of the <code>widget</code> option</td>
+            <td><code translate="no">mixed</code></td>
+            <td>The value of the <code translate="no">widget</code> option</td>
         </tr>
         <tr>
             <td>type</td>
-            <td><code>string</code></td>
+            <td><code translate="no">string</code></td>
             <td>Multiple lines of text here, to show
 that off</td>
         </tr>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -9,12 +9,12 @@
         <a class="headerlink" href="#datetimetype-field" title="Permalink to this headline">DateTimeType Field</a>
     </h1>
     <p>This field type allows the user to modify data that represents a specific
-date and time (e.g. <code translate="no">1984-06-05 12:15:30</code>).</p>
+date and time (e.g. <code translate="no" class="notranslate">1984-06-05 12:15:30</code>).</p>
     <table>
         <tbody>
         <tr>
             <td>Underlying Data Type</td>
-            <td>can be <code translate="no">DateTime</code>, string, timestamp, or array (see the <code translate="no">input</code> option)</td>
+            <td>can be <code translate="no" class="notranslate">DateTime</code>, string, timestamp, or array (see the <code translate="no" class="notranslate">input</code> option)</td>
         </tr>
         <tr>
             <td>Rendered as</td>
@@ -63,8 +63,8 @@ date and time (e.g. <code translate="no">1984-06-05 12:15:30</code>).</p>
             <h3 id="the-date-format-option">
                 <a class="headerlink" href="#the-date-format-option" title="Permalink to this headline">The date_format Option</a>
             </h3>
-            <p><strong>type</strong>: <code translate="no">integer</code> or <code translate="no">string</code><strong>default</strong>: <code translate="no">IntlDateFormatter::MEDIUM</code></p>
-            <p>Defines the <code translate="no">format</code> option that will be passed down to the date field.
+            <p><strong>type</strong>: <code translate="no" class="notranslate">integer</code> or <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">IntlDateFormatter::MEDIUM</code></p>
+            <p>Defines the <code translate="no" class="notranslate">format</code> option that will be passed down to the date field.
 for more details.</p>
             <div class="admonition admonition-tip ">
                 <p class="admonition-title">
@@ -95,7 +95,7 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
                 <p>Sometimes we add notes. But not too often because they interrupt the flow.
 <a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
             </div>
-            <p>This is included documentation about the <code translate="no">date_widget</code> option.</p>
+            <p>This is included documentation about the <code translate="no" class="notranslate">date_widget</code> option.</p>
         </div>
         <div class="section">
             <h3 id="placeholder">
@@ -104,16 +104,16 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
             <div class="versionadded">
                 <div>
                     <span class="versionmodified">New in version 2.6: </span>
-                    <p>The <code translate="no">placeholder</code> option was introduced in Symfony 2.6 and replaces
-<code translate="no">empty_value</code>, which is available prior to 2.6.
+                    <p>The <code translate="no" class="notranslate">placeholder</code> option was introduced in Symfony 2.6 and replaces
+<code translate="no" class="notranslate">empty_value</code>, which is available prior to 2.6.
 <a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
                 </div>
             </div>
-            <p><strong>type</strong>: <code translate="no">string</code> | <code translate="no">array</code></p>
-            <p>If your widget option is set to <code translate="no">choice</code>, then this field will be represented
-as a series of <code translate="no">select</code> boxes. When the placeholder value is a string,
+            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code> | <code translate="no" class="notranslate">array</code></p>
+            <p>If your widget option is set to <code translate="no" class="notranslate">choice</code>, then this field will be represented
+as a series of <code translate="no" class="notranslate">select</code> boxes. When the placeholder value is a string,
 it will be used as the <strong>blank value</strong> of all select boxes:</p>
-            <div translate="no" class="literal-block loc-1">
+            <div translate="no" class="notranslate literal-block loc-1">
                 <div class="highlight-php">
                     <table class="highlighttable">
                         <tr>
@@ -168,11 +168,11 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
             </div>
             <p>Custom classes for links are also cool:</p>
             <ul class="list-config-options">
-                <li><code translate="no">excluded_ajax_paths</code></li>
-                <li><code translate="no">intercept_redirects</code></li>
-                <li><code translate="no">position</code></li>
-                <li><code translate="no">toolbar</code></li>
-                <li><code translate="no">verbose</code></li>
+                <li><code translate="no" class="notranslate">excluded_ajax_paths</code></li>
+                <li><code translate="no" class="notranslate">intercept_redirects</code></li>
+                <li><code translate="no" class="notranslate">position</code></li>
+                <li><code translate="no" class="notranslate">toolbar</code></li>
+                <li><code translate="no" class="notranslate">verbose</code></li>
                 <li><a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></li>
             </ul>
         </div>
@@ -180,8 +180,8 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
             <h3 id="format">
                 <a class="headerlink" href="#format" title="Permalink to this headline">format</a>
             </h3>
-            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
-            <p>If the <code translate="no">widget</code> option is set to <code translate="no">single_text</code>, this option specifies
+            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
+            <p>If the <code translate="no" class="notranslate">widget</code> option is set to <code translate="no" class="notranslate">single_text</code>, this option specifies
 the format of the input, i.e. how Symfony will interpret the given input
 as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax" class="reference external">Date/Time Format Syntax</a>.</p>
             <div class="admonition-wrapper">
@@ -208,16 +208,16 @@ as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/
             <h3 id="time-widget">
                 <a class="headerlink" href="#time-widget" title="Permalink to this headline">time_widget</a>
             </h3>
-            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">choice</code></p>
-            <p>Defines the <code translate="no">widget</code> option for the <code translate="no">TimeType</code>.</p>
+            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">choice</code></p>
+            <p>Defines the <code translate="no" class="notranslate">widget</code> option for the <code translate="no" class="notranslate">TimeType</code>.</p>
         </div>
         <div class="section">
             <h3 id="widget">
                 <a class="headerlink" href="#widget" title="Permalink to this headline">widget</a>
             </h3>
-            <p><strong>type</strong>: <code translate="no">string</code><strong>default</strong>: <code translate="no">null</code></p>
-            <p>Defines the <code translate="no">widget</code> option for both the <code translate="no">DateType</code>.
-and <code translate="no">TimeType</code>. This can be overridden
+            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">null</code></p>
+            <p>Defines the <code translate="no" class="notranslate">widget</code> option for both the <code translate="no" class="notranslate">DateType</code>.
+and <code translate="no" class="notranslate">TimeType</code>. This can be overridden
 with the <a href="datetime.html#date-widget" class="reference internal">date_widget</a> and <a href="datetime.html#time-widget" class="reference internal">time_widget</a> options.</p>
         </div>
     </div>
@@ -230,16 +230,16 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
         <h3 id="by-reference">
             <a class="headerlink" href="#by-reference" title="Permalink to this headline">by_reference</a>
         </h3>
-        <p><strong>default</strong>: <code translate="no">false</code></p>
-        <p>The <code translate="no">DateTime</code> classes are treated as immutable objects.</p>
+        <p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
+        <p>The <code translate="no" class="notranslate">DateTime</code> classes are treated as immutable objects.</p>
     </div>
     <div class="section">
         <h3 id="error-bubbling">
             <a class="headerlink" href="#error-bubbling" title="Permalink to this headline">error_bubbling</a>
         </h3>
-        <p><strong>default</strong>: <code translate="no">false</code></p>
+        <p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
         <p>We also support code blocks!</p>
-        <div translate="no" class="literal-block loc-1">
+        <div translate="no" class="notranslate literal-block loc-1">
             <div class="highlight-yaml">
                 <table class="highlighttable">
                     <tr>
@@ -267,7 +267,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
             <ul class="simple">
                 <li>
                     <em>YAML</em>
-                    <div translate="no" class="literal-block loc-1">
+                    <div translate="no" class="notranslate literal-block loc-1">
                         <div class="highlight-yaml">
                             <table class="highlighttable">
                                 <tr>
@@ -300,7 +300,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
                 </li>
                 <li>
                     <em>XML</em>
-                    <div translate="no" class="literal-block loc-2">
+                    <div translate="no" class="notranslate literal-block loc-2">
                         <div class="highlight-xml">
                             <table class="highlighttable">
                                 <tr>
@@ -383,7 +383,7 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
                 </li>
                 <li>
                     <em>PHP</em>
-                    <div translate="no" class="literal-block loc-2">
+                    <div translate="no" class="notranslate literal-block loc-2">
                         <div class="highlight-php">
                             <table class="highlighttable">
                                 <tr>
@@ -446,12 +446,12 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
         <tbody>
         <tr>
             <td>widget</td>
-            <td><code translate="no">mixed</code></td>
-            <td>The value of the <code translate="no">widget</code> option</td>
+            <td><code translate="no" class="notranslate">mixed</code></td>
+            <td>The value of the <code translate="no" class="notranslate">widget</code> option</td>
         </tr>
         <tr>
             <td>type</td>
-            <td><code translate="no">string</code></td>
+            <td><code translate="no" class="notranslate">string</code></td>
             <td>Multiple lines of text here, to show
 that off</td>
         </tr>


### PR DESCRIPTION
This is an HTML5 attribute (https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute) used to tell Google Translate to not translate the contents of some elements.

We use the same in the current symfony.com docs, but we use the old `class="notranslate"` technique, because the HTML attribute was not available back then.