### PR TITLE
Tweak the code blocks

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -75,12 +75,13 @@ class CodeNodeRenderer implements NodeRenderer
         }
 
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));
+        $lines = implode("\n", range(1, $numOfLines - 1));
 
         return $this->templateRenderer->render(
             'code.html.twig',
             [
                 'languages' => $languages,
-                'lines' => range(1, $numOfLines - 1),
+                'lines' => $lines,
                 'code' => $highlightedCode,
                 // this is the number of digits of the codeblock lines-of-code
                 // e.g. LOC = 5, digits = 1; LOC = 18, digits = 2

--- a/src/Templates/default/html/code.html.twig
+++ b/src/Templates/default/html/code.html.twig
@@ -1,6 +1,6 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-{{ numLocDigits }} {{ languages|map(language => "codeblock-#{language}")|join(' ') }}">
     <div class="codeblock-scroll">
-        <pre class="codeblock-lines">{{ lines|join("\n") }}</pre>
+        <pre class="codeblock-lines">{{ lines }}</pre>
         <pre class="codeblock-code"><code>{{ code|raw }}</code></pre>
     </div>
 </div>

--- a/src/Templates/default/html/code.html.twig
+++ b/src/Templates/default/html/code.html.twig
@@ -1,18 +1,6 @@
-<div translate="no" class="notranslate literal-block loc-{{ numLocDigits }}">
-    <div class="highlight-{{ language }}">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre>{{ lineNumbers }}</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs {{ languageMapping }}">{{ code|raw }}</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+<div translate="no" class="notranslate codeblock codeblock-loc-{{ numLocDigits }} {{ languages|map(language => "codeblock-#{language}")|join(' ') }}">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">{{ lines|join("\n") }}</pre>
+        <pre class="codeblock-code"><code>{{ code|raw }}</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-bash">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs bash">git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-bash">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code>git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/html-php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-php.html
@@ -1,42 +1,41 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-2">
-    <div class="highlight-html+php">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1 2 3 4 5 6 7 8 9
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-html+php codeblock-html">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9
 10
 11
 12</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs html">
-                            <span class="hljs-comment">&lt;!-- views/layout.php --&gt;</span>
+        <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- views/layout.php --&gt;</span>
 <span class="hljs-meta">&lt;!doctype <span class="hljs-meta-keyword">html</span>&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">html</span>&gt;</span>
-                            <span class="hljs-tag">&lt;<span class="hljs-name">head</span>&gt;</span>
-                            <span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>
-                            <span class="php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-string">'title'</span>; <span class="hljs-meta">?&gt;</span></span>
-                            <span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span>
-                            <span class="hljs-tag">&lt;/<span class="hljs-name">head</span>&gt;</span>
-                            <span class="hljs-tag">&lt;<span class="hljs-name">body</span>&gt;</span>
-                            <span class="php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-string">'body'</span>; <span class="hljs-meta">?&gt;</span></span>
-                            <span class="hljs-tag">&lt;/<span class="hljs-name">body</span>&gt;</span>
-                            <span class="hljs-tag">&lt;/<span class="hljs-name">html</span>&gt;</span>
-                        </pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <span class="hljs-tag">&lt;<span class="hljs-name">head</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-name">title</span>&gt;</span>
+            <span class="php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-string">'title'</span>; <span class="hljs-meta">?&gt;</span></span>
+        <span class="hljs-tag">&lt;/<span class="hljs-name">title</span>&gt;</span>
+    <span class="hljs-tag">&lt;/<span class="hljs-name">head</span>&gt;</span>
+    <span class="hljs-tag">&lt;<span class="hljs-name">body</span>&gt;</span>
+        <span class="php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-string">'body'</span>; <span class="hljs-meta">?&gt;</span></span>
+    <span class="hljs-tag">&lt;/<span class="hljs-name">body</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">html</span>&gt;</span>
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -1,30 +1,21 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-html+twig">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1 2</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs twig">
-                            <span class="hljs-comment">{# some code #}</span>
-                            <span class="xml">
-<span class="hljs-comment">&lt;!-- some code --&gt;</span></span>
-                        </pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html+twig codeblock-twig">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
+<span class="hljs-comment">&lt;!-- some code --&gt;</span>
+</span></code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/html.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-html">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs html"><span class="hljs-comment">&lt;!-- some code --&gt;</span></pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- some code --&gt;</span>
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-ini">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs ini"><span class="hljs-attr">fetch</span> = +refs/notes/*:refs/notes/*</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-ini">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-attr">fetch</span> = +refs/notes/*:refs/notes/*
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -1,40 +1,45 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-2">
-    <div class="highlight-php-annotations">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1 2 3 4 5 6 7 8 9
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php-annotations codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9
 10
 11
 12
 13
 14</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                                                        <pre class="hljs php">
-                                    <span class="hljs-comment">// src/AppBundle/Entity/Transaction.php</span>
-<span class="hljs-keyword">namespace</span> <span class="hljs-title">AppBundle</span>\<span class="hljs-title">Entity</span>; <span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Validator</span>\<span class="hljs-title">Constraints</span> <span class="hljs-title">as</span> <span class="hljs-title">Assert</span>;
-                                    <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Transaction</span>
-</span>
-                                    {
-                                    <span class="hljs-comment">/** * <span class="hljs-doctag">@Assert</span>\Iban( * message="This is not a valid International Bank Account Number (IBAN)." * ) */</span>
-                                    <span class="hljs-keyword">protected</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>bankAccountNumber</span>;
+        <pre class="codeblock-code"><code><span class="hljs-comment">// src/AppBundle/Entity/Transaction.php</span>
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">AppBundle</span>\<span class="hljs-title">Entity</span>;
+
+<span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Validator</span>\<span class="hljs-title">Constraints</span> <span class="hljs-title">as</span> <span class="hljs-title">Assert</span>;
+
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Transaction</span>
+</span>{
+    <span class="hljs-comment">/**
+     * <span class="hljs-doctag">@Assert</span>\Iban(
+     *     message="This is not a valid International Bank Account Number (IBAN)."
+     * )
+     */</span>
+    <span class="hljs-keyword">protected</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>bankAccountNumber</span>;
 }
-                                </pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -1,40 +1,31 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-php">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1
- 2
- 3
- 4
- 5
- 6
- 7</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs php">
-                                    <span class="hljs-comment">// config/routes.php</span>
-<span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>; <span class="hljs-keyword">return</span>
-                                    <span class="hljs-function">
-                                        <span class="hljs-keyword">function</span>
-                                        <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span>
-                                    </span>
-                                    { <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
-};</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span>
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>;
+
+<span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>{
+    <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>])
+        <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
+};
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-terminal">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs bash">git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-terminal codeblock-bash">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code>git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-text">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs text">some text</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-text">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code>some text
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-twig">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs twig"><span class="hljs-comment">{# some code #}</span></pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-twig">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
+</span></code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/xml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/xml.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-xml">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs xml"><span class="hljs-comment">&lt;!-- some code --&gt;</span></pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-xml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- some code --&gt;</span>
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/code-blocks/yaml.html
+++ b/tests/fixtures/expected/blocks/code-blocks/yaml.html
@@ -1,26 +1,19 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-yaml">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs yaml"><span class="hljs-comment"># some code</span></pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment"># some code</span>
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/admonition.html
+++ b/tests/fixtures/expected/blocks/directives/admonition.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-default screencast_class">
-    <p class="admonition-title"> Screencast </p>
-    <p>Do you prefer video tutorials? Check out the the screencasts.</p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-default screencast_class">
+    <p class="admonition-title">
+                Screencast
+    </p><p>Do you prefer video tutorials? Check out the the screencasts.</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/best-practice.html
+++ b/tests/fixtures/expected/blocks/directives/best-practice.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-best-practice ">
-    <p class="admonition-title"> Best Practice </p>
-    <p>Use the bcrypt encoder for hashing your users' passwords.</p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-best-practice ">
+    <p class="admonition-title">
+                Best Practice
+    </p><p>Use the bcrypt encoder for hashing your users' passwords.</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/caution.html
+++ b/tests/fixtures/expected/blocks/directives/caution.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-caution ">
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-caution ">
     <p class="admonition-title">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        Caution
-    </p>
-    <p>Using too many sidebars or caution directives can be distracting!</p>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                Caution
+    </p><p>Using too many sidebars or caution directives can be distracting!</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/class.html
+++ b/tests/fixtures/expected/blocks/directives/class.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<ul class="a-class">
-    <li>list-item-1</li>
-    <li>list-item-2</li>
-    <li>list-item-3</li>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <ul class="a-class"><li>list-item-1</li>
+<li>list-item-2</li>
+<li>list-item-3</li>
 </ul>
 
 <p class="another-class">some text</p>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -1,46 +1,35 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="configuration-block"><ul class="simple"><li><em>YAML</em><div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-yaml">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs yaml"><span class="hljs-comment"># app/config/services.yml</span></pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="configuration-block">
+    <ul class="simple">
+                    <li>
+                <em>YAML</em>
+                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/services.yml</span>
+</code></pre>
     </div>
-</div></li><li><em>PHP</em><div translate="no" class="notranslate literal-block loc-1">
-                <div class="highlight-php">
-                    <table class="highlighttable">
-                        <tr>
-                            <td class="linenos">
-                                <div class="linenodiv">
-                                    <pre> 1</pre>
-                                </div>
-                            </td>
-                            <td class="code">
-                                <div class="highlight">
-                                    <pre class="hljs php"><span class="hljs-comment">// config/routes.php</span></pre>
-                                </div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-        </li>
-    </ul>
 </div>
-</body>
+            </li>
+                    <li>
+                <em>PHP</em>
+                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span>
+</code></pre>
+    </div>
+</div>
+            </li>
+            </ul></div>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/note-code-block-nested.html
@@ -1,35 +1,25 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-note ">
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-note ">
     <p class="admonition-title">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-        </svg>
-        Note
-    </p>
-    <p>test</p>
-    <div translate="no" class="notranslate literal-block loc-1">
-        <div class="highlight-php">
-            <table class="highlighttable">
-                <tr>
-                    <td class="linenos">
-                        <div class="linenodiv">
-                            <pre> 1</pre>
-                        </div>
-                    </td>
-                    <td class="code">
-                        <div class="highlight">
-                            <pre class="hljs php"><span class="hljs-comment">// code</span></pre>
-                        </div>
-                    </td>
-                </tr>
-            </table>
-        </div>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+                Note
+    </p><p>test</p>
+<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// code</span>
+</code></pre>
     </div>
 </div>
-</body>
+</div>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/note.html
+++ b/tests/fixtures/expected/blocks/directives/note.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-note ">
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-note ">
     <p class="admonition-title">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-        </svg>
-        Note
-    </p>
-    <p>Sometimes we add notes. But not too often because they interrupt the flow.</p>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+                Note
+    </p><p>Sometimes we add notes. But not too often because they interrupt the flow.</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/seealso.html
+++ b/tests/fixtures/expected/blocks/directives/seealso.html
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-seealso ">
-    <p class="admonition-title"> See also </p>
-    <p>Also check out the homepage</p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-seealso ">
+    <p class="admonition-title">
+                See also
+    </p><p>Also check out the homepage</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar-code-block-nested.html
@@ -1,33 +1,22 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition-wrapper">
-    <div class="admonition admonition-sidebar">
-        <p class="sidebar-title">The sidebar's title</p>
-        <p>some text before code block</p>
-        <div translate="no" class="notranslate literal-block loc-1">
-            <div class="highlight-php">
-                <table class="highlighttable">
-                    <tr>
-                        <td class="linenos">
-                            <div class="linenodiv">
-                                <pre> 1</pre>
-                            </div>
-                        </td>
-                        <td class="code">
-                            <div class="highlight">
-                                <pre class="hljs php"><span class="hljs-comment">// some code</span></pre>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </div>
-        <p>some text after code block</p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title">The sidebar's title</p><p>some text before code block</p>
+<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// some code</span>
+</code></pre>
     </div>
 </div>
-</body>
+<p>some text after code block</p>
+</div></div>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/sidebar.html
+++ b/tests/fixtures/expected/blocks/directives/sidebar.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition-wrapper">
-    <div class="admonition admonition-sidebar">
-        <p class="sidebar-title">The sidebar's title</p>
-        <p>some text inside sidebar</p>
-    </div>
-</div>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title">The sidebar's title</p><p>some text inside sidebar</p>
+</div></div>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/tip.html
+++ b/tests/fixtures/expected/blocks/directives/tip.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="admonition admonition-tip ">
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="admonition admonition-tip ">
     <p class="admonition-title">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-        </svg>
-        Tip
-    </p>
-    <p>This is a little tip about something! We an also talk about specific</p>
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
+                Tip
+    </p><p>This is a little tip about something! We an also talk about specific</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/topic.html
+++ b/tests/fixtures/expected/blocks/directives/topic.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="topic">
-    <p class="topic-title">Example</p>
-    <p>Here is a sample comment for a bug report that could be reproduced.</p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="topic">
+    <p class="topic-title">Example</p><p>Here is a sample comment for a bug report that could be reproduced.</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/directives/versionadded.html
+++ b/tests/fixtures/expected/blocks/directives/versionadded.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="versionadded">
-    <div>
-        <span class="versionmodified">New in version 4.1: </span>
-        <p>This option was introduced in Symfony 2.6 and replaces another option, which is available prior to 2.6.</p>
-    </div>
-</div>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="versionadded"><div><span class="versionmodified">New in version 4.1: </span><p>This option was introduced in Symfony 2.6 and replaces another option, which is available prior to 2.6.</p>
+</div></div>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/nodes/list.html
+++ b/tests/fixtures/expected/blocks/nodes/list.html
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<ul>
-    <li>List item 1</li>
-    <li>List item 2</li>
-    <li>List item 3</li>
-    <li>List item 4</li>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <ul><li>List item 1</li>
+<li>List item 2</li>
+<li>List item 3</li>
+<li>List item 4</li>
 </ul>
-</body>
+
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -1,41 +1,32 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p>here is some php code from literal:</p>
-<div translate="no" class="notranslate literal-block loc-1">
-    <div class="highlight-php">
-        <table class="highlighttable">
-            <tr>
-                <td class="linenos">
-                    <div class="linenodiv">
-                        <pre> 1
- 2
- 3
- 4
- 5
- 6
- 7</pre>
-                    </div>
-                </td>
-                <td class="code">
-                    <div class="highlight">
-                        <pre class="hljs php">
-                                    <span class="hljs-comment">// config/routes.php</span>
-<span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>; <span class="hljs-keyword">return</span>
-                                    <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>
-                                    {                                    <span class="hljs-variable">
-                                        <span class="hljs-variable-other-marker">$</span>
-                                        routes
-                                    </span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>]) <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
-};</pre>
-                    </div>
-                </td>
-            </tr>
-        </table>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p>here is some php code from literal:</p>
+<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span>
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Routing</span>\<span class="hljs-title">Loader</span>\<span class="hljs-title">Configurator</span>;
+
+<span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>{
+    <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>])
+        <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
+};
+</code></pre>
     </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/nodes/tables.html
+++ b/tests/fixtures/expected/blocks/nodes/tables.html
@@ -1,94 +1,100 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<table>
-    <thead>
-    <tr>
-        <th>Route path</th>
-        <th>If the requested URL is /foo</th>
-        <th>If the requested URL is /foo/</th>
-    </tr>
-    </thead>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <table>
+            <thead>
+                            <tr>
+                                            <th>Route path</th>
+                                            <th>If the requested URL is /foo</th>
+                                            <th>If the requested URL is /foo/</th>
+                                    </tr>
+                    </thead>
+    
     <tbody>
-    <tr>
-        <td>/foo</td>
-        <td>It matches (200 status response)</td>
-        <td>It doesn't match (404 status response)</td>
-    </tr>
-    <tr>
-        <td>/foo/</td>
-        <td>It makes a 301 redirect to /foo/</td>
-        <td>It matches (200 status response)</td>
-    </tr>
-    </tbody>
+                    <tr>
+                                    <td>/foo</td>
+                                    <td>It matches (200 status response)</td>
+                                    <td>It doesn't match (404 status response)</td>
+                            </tr>
+                    <tr>
+                                    <td>/foo/</td>
+                                    <td>It makes a 301 redirect to /foo/</td>
+                                    <td>It matches (200 status response)</td>
+                            </tr>
+            </tbody>
 </table>
 <table>
+    
     <tbody>
-    <tr>
-        <td>Cell 1</td>
-        <td>Cell 2</td>
-    </tr>
-    <tr>
-        <td>Cell 3</td>
-        <td>Cell 4</td>
-    </tr>
-    <tr>
-        <td>Cell 5</td>
-        <td>Cell 6
+                    <tr>
+                                    <td>Cell 1</td>
+                                    <td>Cell 2</td>
+                            </tr>
+                    <tr>
+                                    <td>Cell 3</td>
+                                    <td>Cell 4</td>
+                            </tr>
+                    <tr>
+                                    <td>Cell 5</td>
+                                    <td>Cell 6
 extra line</td>
-    </tr>
-    </tbody>
+                            </tr>
+            </tbody>
 </table>
 <table>
-    <thead>
-    <tr>
-        <th>Cell 1</th>
-        <th>Cell 2</th>
-    </tr>
-    </thead>
+            <thead>
+                            <tr>
+                                            <th>Cell 1</th>
+                                            <th>Cell 2</th>
+                                    </tr>
+                    </thead>
+    
     <tbody>
-    <tr>
-        <td>Cell 3</td>
-        <td>Cell 4</td>
-    </tr>
-    <tr>
-        <td>Cell 5</td>
-        <td>Cell 6
+                    <tr>
+                                    <td>Cell 3</td>
+                                    <td>Cell 4</td>
+                            </tr>
+                    <tr>
+                                    <td>Cell 5</td>
+                                    <td>Cell 6
 extra line</td>
-    </tr>
-    </tbody>
+                            </tr>
+            </tbody>
 </table>
 <table>
-    <thead>
-    <tr>
-        <th>Cell 1</th>
-        <th>Cell 2</th>
-    </tr>
-    </thead>
+            <thead>
+                            <tr>
+                                            <th>Cell 1</th>
+                                            <th>Cell 2</th>
+                                    </tr>
+                    </thead>
+    
     <tbody>
-    <tr>
-        <td>Cell 3</td>
-        <td>Cell 4</td>
-    </tr>
-    <tr>
-        <td>Cell 5</td>
-        <td>
-            <ul>
-                <li>List item 1</li>
-                <li>List item 2</li>
-                <li>List item 3</li>
-                <li>List item 4</li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td>Cell 7</td>
-        <td>Cell 8</td>
-    </tr>
-    </tbody>
+                    <tr>
+                                    <td>Cell 3</td>
+                                    <td>Cell 4</td>
+                            </tr>
+                    <tr>
+                                    <td>Cell 5</td>
+                                    <td><ul><li>List item 1</li>
+<li>List item 2</li>
+<li>List item 3</li>
+<li>List item 4</li>
+</ul>
+</td>
+                            </tr>
+                    <tr>
+                                    <td>Cell 7</td>
+                                    <td>Cell 8</td>
+                            </tr>
+            </tbody>
 </table>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/class.html
+++ b/tests/fixtures/expected/blocks/references/class.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.html" class="reference external" title="Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel">ContainerAwareHttpKernel</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.html" class="reference external" title="Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel">ContainerAwareHttpKernel</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/method.html
+++ b/tests/fixtures/expected/blocks/references/method.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpFoundation/RequestStack.html#method_getCurrentRequest" class="reference external" title="Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest()">getCurrentRequest()</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpFoundation/RequestStack.html#method_getCurrentRequest" class="reference external" title="Symfony\Component\HttpFoundation\RequestStack::getCurrentRequest()">getCurrentRequest()</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/namespace.html
+++ b/tests/fixtures/expected/blocks/references/namespace.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpFoundation.html" class="reference external" title="Symfony\Component\HttpFoundation">HttpFoundation</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://api.symfony.com/4.0/Symfony/Component/HttpFoundation.html" class="reference external" title="Symfony\Component\HttpFoundation">HttpFoundation</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/php-class.html
+++ b/tests/fixtures/expected/blocks/references/php-class.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://secure.php.net/manual/en/class.arrayaccess.php" class="reference external" title="ArrayAccess">ArrayAccess</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://secure.php.net/manual/en/class.arrayaccess.php" class="reference external" title="ArrayAccess">ArrayAccess</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/php-function.html
+++ b/tests/fixtures/expected/blocks/references/php-function.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://secure.php.net/manual/en/function.trigger-error.php" class="reference external" title="trigger_error">trigger_error</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://secure.php.net/manual/en/function.trigger-error.php" class="reference external" title="trigger_error">trigger_error</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/blocks/references/php-method.html
+++ b/tests/fixtures/expected/blocks/references/php-method.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<p><a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale">Locale::getDefault()</a></p>
-</body>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <p><a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale">Locale::getDefault()</a></p>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/doc-reference/index.html
+++ b/tests/fixtures/expected/doc-reference/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
-    <h1 id="a-test-for-doc-link">
-        <a class="headerlink" href="#a-test-for-doc-link" title="Permalink to this headline">A test for doc link</a>
-    </h1>
-    <p><a href="file.html" class="reference internal">A doc test</a></p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="a-test-for-doc-link"><a class="headerlink" href="#a-test-for-doc-link" title="Permalink to this headline">A test for doc link</a></h1>
+<p><a href="file.html" class="reference internal">A doc test</a></p>
+
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -1,315 +1,223 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
-    <h1 id="datetimetype-field">
-        <a class="headerlink" href="#datetimetype-field" title="Permalink to this headline">DateTimeType Field</a>
-    </h1>
-    <p>This field type allows the user to modify data that represents a specific
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="datetimetype-field"><a class="headerlink" href="#datetimetype-field" title="Permalink to this headline">DateTimeType Field</a></h1>
+<p>This field type allows the user to modify data that represents a specific
 date and time (e.g. <code translate="no" class="notranslate">1984-06-05 12:15:30</code>).</p>
-    <table>
-        <tbody>
-        <tr>
-            <td>Underlying Data Type</td>
-            <td>can be <code translate="no" class="notranslate">DateTime</code>, string, timestamp, or array (see the <code translate="no" class="notranslate">input</code> option)</td>
-        </tr>
-        <tr>
-            <td>Rendered as</td>
-            <td>single text box or three select fields</td>
-        </tr>
-        <tr>
-            <td>Options</td>
-            <td>
-                <ul>
-                    <li><a href="datetime.html#the-date-format-option" class="reference internal">The date_format Option</a></li>
-                    <li><a href="datetime.html#date-widget" class="reference internal">date_widget</a></li>
-                    <li><a href="datetime.html#placeholder" class="reference internal">placeholder</a></li>
-                    <li><a href="datetime.html#format" class="reference internal">format</a></li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td>Overridden options</td>
-            <td>
-                <ul>
-                    <li><a href="datetime.html#by-reference" class="reference internal">by_reference</a></li>
-                    <li><a href="datetime.html#error-bubbling" class="reference internal">error_bubbling</a></li>
-                </ul>
-            </td>
-        </tr>
-        <tr>
-            <td>Parent type</td>
-            <td><a href="form/form_type.html" class="reference internal">FormType</a></td>
-        </tr>
-        <tr>
-            <td>Class</td>
-            <td><a href="https://api.symfony.com/4.0/Symfony/Component/Form/Extension/Core/Type/DateTimeType.html" class="reference external" title="Symfony\Component\Form\Extension\Core\Type\DateTimeType">DateTimeType</a></td>
-        </tr>
-        <tr>
-            <td>Ref</td>
-            <td><a href="index.html#reference-forms-type-date-format" class="reference internal">Some Test Docs!</a>
+<table>
+    
+    <tbody>
+                    <tr>
+                                    <td>Underlying Data Type</td>
+                                    <td>can be <code translate="no" class="notranslate">DateTime</code>, string, timestamp, or array (see the <code translate="no" class="notranslate">input</code> option)</td>
+                            </tr>
+                    <tr>
+                                    <td>Rendered as</td>
+                                    <td>single text box or three select fields</td>
+                            </tr>
+                    <tr>
+                                    <td>Options</td>
+                                    <td><ul><li><a href="datetime.html#the-date-format-option" class="reference internal">The date_format Option</a></li>
+<li><a href="datetime.html#date-widget" class="reference internal">date_widget</a></li>
+<li><a href="datetime.html#placeholder" class="reference internal">placeholder</a></li>
+<li><a href="datetime.html#format" class="reference internal">format</a></li>
+</ul>
+</td>
+                            </tr>
+                    <tr>
+                                    <td>Overridden options</td>
+                                    <td><ul><li><a href="datetime.html#by-reference" class="reference internal">by_reference</a></li>
+<li><a href="datetime.html#error-bubbling" class="reference internal">error_bubbling</a></li>
+</ul>
+</td>
+                            </tr>
+                    <tr>
+                                    <td>Parent type</td>
+                                    <td><a href="form/form_type.html" class="reference internal">FormType</a></td>
+                            </tr>
+                    <tr>
+                                    <td>Class</td>
+                                    <td><a href="https://api.symfony.com/4.0/Symfony/Component/Form/Extension/Core/Type/DateTimeType.html" class="reference external" title="Symfony\Component\Form\Extension\Core\Type\DateTimeType">DateTimeType</a></td>
+                            </tr>
+                    <tr>
+                                    <td>Ref</td>
+                                    <td><a href="index.html#reference-forms-type-date-format" class="reference internal">Some Test Docs!</a>
 <a href="form/form_type.html#internal-reference" class="reference internal">Test reference</a></td>
-        </tr>
-        </tbody>
-    </table>
-    <div class="section">
-        <h2 id="field-options">
-            <a class="headerlink" href="#field-options" title="Permalink to this headline">Field Options</a>
-        </h2>
-        <div class="section">
-            <h3 id="the-date-format-option">
-                <a class="headerlink" href="#the-date-format-option" title="Permalink to this headline">The date_format Option</a>
-            </h3>
-            <p><strong>type</strong>: <code translate="no" class="notranslate">integer</code> or <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">IntlDateFormatter::MEDIUM</code></p>
-            <p>Defines the <code translate="no" class="notranslate">format</code> option that will be passed down to the date field.
+                            </tr>
+            </tbody>
+</table>
+<div class="section">
+<h2 id="field-options"><a class="headerlink" href="#field-options" title="Permalink to this headline">Field Options</a></h2>
+<div class="section">
+<h3 id="the-date-format-option"><a class="headerlink" href="#the-date-format-option" title="Permalink to this headline">The date_format Option</a></h3>
+<p><strong>type</strong>: <code translate="no" class="notranslate">integer</code> or <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">IntlDateFormatter::MEDIUM</code></p>
+<p>Defines the <code translate="no" class="notranslate">format</code> option that will be passed down to the date field.
 for more details.</p>
-            <div class="admonition admonition-tip ">
-                <p class="admonition-title">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-                    </svg>
-                    Tip
-                </p>
-                <p>This is a little tip about something! We an also talk about specific
+<div class="admonition admonition-tip ">
+    <p class="admonition-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>
+                Tip
+    </p><p>This is a little tip about something! We an also talk about specific
 methods: <a href="https://api.symfony.com/4.0/Symfony/Component/BrowserKit/Client.html#method_doRequest" class="reference external" title="Symfony\Component\BrowserKit\Client::doRequest()">doRequest()</a>.
 Or a namespace: <a href="https://api.symfony.com/4.0/Symfony/Component/Validator/Constraints.html" class="reference external" title="Symfony\Component\Validator\Constraints">Constraints</a>.
 Or a PHP function: <a href="https://secure.php.net/manual/en/function.parse-ini-file.php" class="reference external" title="parse_ini_file">parse_ini_file</a>.
 Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php" class="reference external" title="Locale">Locale::getDefault()</a>.</p>
-            </div>
-        </div>
-        <div class="section">
-            <h3 id="date-widget">
-                <a class="headerlink" href="#date-widget" title="Permalink to this headline">date_widget</a>
-            </h3>
-            <p>Date widget!</p>
-            <div class="admonition admonition-note ">
-                <p class="admonition-title">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                    Note
-                </p>
-                <p>Sometimes we add notes. But not too often because they interrupt the flow.
-<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
-            </div>
-            <p>This is included documentation about the <code translate="no" class="notranslate">date_widget</code> option.</p>
-        </div>
-        <div class="section">
-            <h3 id="placeholder">
-                <a class="headerlink" href="#placeholder" title="Permalink to this headline">placeholder</a>
-            </h3>
-            <div class="versionadded">
-                <div>
-                    <span class="versionmodified">New in version 2.6: </span>
-                    <p>The <code translate="no" class="notranslate">placeholder</code> option was introduced in Symfony 2.6 and replaces
-<code translate="no" class="notranslate">empty_value</code>, which is available prior to 2.6.
-<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
-                </div>
-            </div>
-            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code> | <code translate="no" class="notranslate">array</code></p>
-            <p>If your widget option is set to <code translate="no" class="notranslate">choice</code>, then this field will be represented
-as a series of <code translate="no" class="notranslate">select</code> boxes. When the placeholder value is a string,
-it will be used as the <strong>blank value</strong> of all select boxes:</p>
-            <div translate="no" class="notranslate literal-block loc-1">
-                <div class="highlight-php">
-                    <table class="highlighttable">
-                        <tr>
-                            <td class="linenos">
-                                <div class="linenodiv">
-                                    <pre> 1 2 3 4 5</pre>
-                                </div>
-                            </td>
-                            <td class="code">
-                                <div class="highlight">
-                                    <pre class="hljs php">
-                                                        <span class="hljs-keyword">use</span>
-                                                        <span class="hljs-title">Symfony</span>
-                                                        \
-                                                        <span class="hljs-title">Component</span>
-                                                        \
-                                                        <span class="hljs-title">Form</span>
-                                                        \
-                                                        <span class="hljs-title">Extension</span>
-                                                        \
-                                                        <span class="hljs-title">Core</span>
-                                                        \
-                                                        <span class="hljs-title">Type</span>
-                                                        \
-                                                        <span class="hljs-title">DateTimeType</span>
-                                                        ; 
-                                                        <span class="hljs-variable">
-                                                            <span class="hljs-variable-other-marker">$</span>
-                                                            builder
-                                                        </span>
-                                                        <span class="hljs-operator">-&gt;</span>
-                                                        add(
-                                                        <span class="hljs-string">'startDateTime'</span>
-                                                        , DateTimeType
-                                                        <span class="hljs-operator">::</span>
-                                                        class, 
-                                                        <span class="hljs-keyword">array</span>
-                                                        ( 
-                                                        <span class="hljs-string">'placeholder'</span>
-                                                        =&gt; 
-                                                        <span class="hljs-string">'Select a value'</span>
-                                                        ,
-));
-                                                    </pre>
-                                </div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <div class="admonition admonition-seealso ">
-                <p class="admonition-title"> See also </p>
-                <p>Also check out the homepage - <a href="index.html" class="reference internal">Some Test Docs!</a>.
-<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
-            </div>
-            <p>Custom classes for links are also cool:</p>
-            <ul class="list-config-options">
-                <li><code translate="no" class="notranslate">excluded_ajax_paths</code></li>
-                <li><code translate="no" class="notranslate">intercept_redirects</code></li>
-                <li><code translate="no" class="notranslate">position</code></li>
-                <li><code translate="no" class="notranslate">toolbar</code></li>
-                <li><code translate="no" class="notranslate">verbose</code></li>
-                <li><a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></li>
-            </ul>
-        </div>
-        <div class="section">
-            <h3 id="format">
-                <a class="headerlink" href="#format" title="Permalink to this headline">format</a>
-            </h3>
-            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
-            <p>If the <code translate="no" class="notranslate">widget</code> option is set to <code translate="no" class="notranslate">single_text</code>, this option specifies
-the format of the input, i.e. how Symfony will interpret the given input
-as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax" class="reference external">Date/Time Format Syntax</a>.</p>
-            <div class="admonition-wrapper">
-                <div class="admonition admonition-sidebar">
-                    <p class="sidebar-title">Everyone loves sidebars</p>
-                    <p>But do they really? They also get in the way!</p>
-                </div>
-            </div>
-            <div class="admonition admonition-caution ">
-                <p class="admonition-title">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                    Caution
-                </p>
-                <p>Using too many sidebars or caution directives can be distracting!</p>
-            </div>
-            <div class="admonition admonition-best-practice ">
-                <p class="admonition-title"> Best Practice </p>
-                <p>Use the bcrypt encoder for hashing your users' passwords.</p>
-            </div>
-        </div>
-        <div class="section">
-            <h3 id="time-widget">
-                <a class="headerlink" href="#time-widget" title="Permalink to this headline">time_widget</a>
-            </h3>
-            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">choice</code></p>
-            <p>Defines the <code translate="no" class="notranslate">widget</code> option for the <code translate="no" class="notranslate">TimeType</code>.</p>
-        </div>
-        <div class="section">
-            <h3 id="widget">
-                <a class="headerlink" href="#widget" title="Permalink to this headline">widget</a>
-            </h3>
-            <p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">null</code></p>
-            <p>Defines the <code translate="no" class="notranslate">widget</code> option for both the <code translate="no" class="notranslate">DateType</code>.
-and <code translate="no" class="notranslate">TimeType</code>. This can be overridden
-with the <a href="datetime.html#date-widget" class="reference internal">date_widget</a> and <a href="datetime.html#time-widget" class="reference internal">time_widget</a> options.</p>
-        </div>
-    </div>
+</div>
 </div>
 <div class="section">
-    <h2 id="overridden-options">
-        <a class="headerlink" href="#overridden-options" title="Permalink to this headline">Overridden Options</a>
-    </h2>
-    <div class="section">
-        <h3 id="by-reference">
-            <a class="headerlink" href="#by-reference" title="Permalink to this headline">by_reference</a>
-        </h3>
-        <p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
-        <p>The <code translate="no" class="notranslate">DateTime</code> classes are treated as immutable objects.</p>
+<h3 id="date-widget"><a class="headerlink" href="#date-widget" title="Permalink to this headline">date_widget</a></h3>
+<p>Date widget!</p>
+<div class="admonition admonition-note ">
+    <p class="admonition-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+                Note
+    </p><p>Sometimes we add notes. But not too often because they interrupt the flow.
+<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
+</div>
+<p>This is included documentation about the <code translate="no" class="notranslate">date_widget</code> option.</p>
+</div>
+<div class="section">
+<h3 id="placeholder"><a class="headerlink" href="#placeholder" title="Permalink to this headline">placeholder</a></h3>
+<div class="versionadded"><div><span class="versionmodified">New in version 2.6: </span><p>The <code translate="no" class="notranslate">placeholder</code> option was introduced in Symfony 2.6 and replaces
+<code translate="no" class="notranslate">empty_value</code>, which is available prior to 2.6.
+<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
+</div></div>
+<p><strong>type</strong>: <code translate="no" class="notranslate">string</code> | <code translate="no" class="notranslate">array</code></p>
+<p>If your widget option is set to <code translate="no" class="notranslate">choice</code>, then this field will be represented
+as a series of <code translate="no" class="notranslate">select</code> boxes. When the placeholder value is a string,
+it will be used as the <strong>blank value</strong> of all select boxes:</p>
+<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5</pre>
+        <pre class="codeblock-code"><code><span class="hljs-keyword">use</span> <span class="hljs-title">Symfony</span>\<span class="hljs-title">Component</span>\<span class="hljs-title">Form</span>\<span class="hljs-title">Extension</span>\<span class="hljs-title">Core</span>\<span class="hljs-title">Type</span>\<span class="hljs-title">DateTimeType</span>;
+
+<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>builder</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'startDateTime'</span>, DateTimeType<span class="hljs-operator">::</span>class, <span class="hljs-keyword">array</span>(
+    <span class="hljs-string">'placeholder'</span> =&gt; <span class="hljs-string">'Select a value'</span>,
+));
+</code></pre>
     </div>
-    <div class="section">
-        <h3 id="error-bubbling">
-            <a class="headerlink" href="#error-bubbling" title="Permalink to this headline">error_bubbling</a>
-        </h3>
-        <p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
-        <p>We also support code blocks!</p>
-        <div translate="no" class="notranslate literal-block loc-1">
-            <div class="highlight-yaml">
-                <table class="highlighttable">
-                    <tr>
-                        <td class="linenos">
-                            <div class="linenodiv">
-                                <pre> 1 2 3</pre>
-                            </div>
-                        </td>
-                        <td class="code">
-                            <div class="highlight">
-                                <pre class="hljs yaml">
-                                                        <span class="hljs-comment"># app/config/parameters.yml</span>
-                                                        <span class="hljs-attr">parameters:</span>
-                                                        <span class="hljs-attr">database_driver:</span>
-                                                        <span class="hljs-string">pdo_mysql</span>
-                                                    </pre>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </div>
-        <p>And configuration blocks:</p>
-        <div class="configuration-block">
-            <ul class="simple">
-                <li>
-                    <em>YAML</em>
-                    <div translate="no" class="notranslate literal-block loc-1">
-                        <div class="highlight-yaml">
-                            <table class="highlighttable">
-                                <tr>
-                                    <td class="linenos">
-                                        <div class="linenodiv">
-                                            <pre> 1 2 3 4 5 6 7</pre>
-                                        </div>
-                                    </td>
-                                    <td class="code">
-                                        <div class="highlight">
-                                            <pre class="hljs yaml">
-                                                                    <span class="hljs-comment"># app/config/config.yml</span>
-                                                                    <span class="hljs-attr">framework:</span>
-                                                                    <span class="hljs-attr">secret:</span>
-                                                                    <span class="hljs-string">'%secret%'</span>
-                                                                    <span class="hljs-attr">router:</span>
-                                                                    <span class="hljs-string">{</span>
-                                                                    <span class="hljs-attr">resource:</span>
-                                                                    <span class="hljs-string">'%kernel.root_dir%/config/routing.yml'</span>
-                                                                    <span class="hljs-string">}</span>
-                                                                    <span class="hljs-comment"># ...</span>
-                                                                    <span class="hljs-comment"># ...</span>
-                                                                </pre>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <em>XML</em>
-                    <div translate="no" class="notranslate literal-block loc-2">
-                        <div class="highlight-xml">
-                            <table class="highlighttable">
-                                <tr>
-                                    <td class="linenos">
-                                        <div class="linenodiv">
-                                            <pre> 1 2 3 4 5 6 7 8 9
+</div>
+<div class="admonition admonition-seealso ">
+    <p class="admonition-title">
+                See also
+    </p><p>Also check out the homepage - <a href="index.html" class="reference internal">Some Test Docs!</a>.
+<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
+</div>
+<p>Custom classes for links are also cool:</p>
+<ul class="list-config-options"><li><code translate="no" class="notranslate">excluded_ajax_paths</code></li>
+<li><code translate="no" class="notranslate">intercept_redirects</code></li>
+<li><code translate="no" class="notranslate">position</code></li>
+<li><code translate="no" class="notranslate">toolbar</code></li>
+<li><code translate="no" class="notranslate">verbose</code></li>
+<li><a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></li>
+</ul>
+
+</div>
+<div class="section">
+<h3 id="format"><a class="headerlink" href="#format" title="Permalink to this headline">format</a></h3>
+<p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
+<p>If the <code translate="no" class="notranslate">widget</code> option is set to <code translate="no" class="notranslate">single_text</code>, this option specifies
+the format of the input, i.e. how Symfony will interpret the given input
+as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax" class="reference external">Date/Time Format Syntax</a>.</p>
+<div class="admonition-wrapper"><div class="admonition admonition-sidebar"><p class="sidebar-title">Everyone loves sidebars</p><p>But do they really? They also get in the way!</p>
+</div></div>
+<div class="admonition admonition-caution ">
+    <p class="admonition-title">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                Caution
+    </p><p>Using too many sidebars or caution directives can be distracting!</p>
+</div>
+<div class="admonition admonition-best-practice ">
+    <p class="admonition-title">
+                Best Practice
+    </p><p>Use the bcrypt encoder for hashing your users' passwords.</p>
+</div>
+</div>
+<div class="section">
+<h3 id="time-widget"><a class="headerlink" href="#time-widget" title="Permalink to this headline">time_widget</a></h3>
+<p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">choice</code></p>
+<p>Defines the <code translate="no" class="notranslate">widget</code> option for the <code translate="no" class="notranslate">TimeType</code>.</p>
+</div>
+<div class="section">
+<h3 id="widget"><a class="headerlink" href="#widget" title="Permalink to this headline">widget</a></h3>
+<p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">null</code></p>
+<p>Defines the <code translate="no" class="notranslate">widget</code> option for both the <code translate="no" class="notranslate">DateType</code>.
+and <code translate="no" class="notranslate">TimeType</code>. This can be overridden
+with the <a href="datetime.html#date-widget" class="reference internal">date_widget</a> and <a href="datetime.html#time-widget" class="reference internal">time_widget</a> options.</p>
+</div>
+</div>
+</div>
+<div class="section">
+<h2 id="overridden-options"><a class="headerlink" href="#overridden-options" title="Permalink to this headline">Overridden Options</a></h2>
+<div class="section">
+<h3 id="by-reference"><a class="headerlink" href="#by-reference" title="Permalink to this headline">by_reference</a></h3>
+<p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
+<p>The <code translate="no" class="notranslate">DateTime</code> classes are treated as immutable objects.</p>
+</div>
+<div class="section">
+<h3 id="error-bubbling"><a class="headerlink" href="#error-bubbling" title="Permalink to this headline">error_bubbling</a></h3>
+<p><strong>default</strong>: <code translate="no" class="notranslate">false</code></p>
+<p>We also support code blocks!</p>
+<div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/parameters.yml</span>
+<span class="hljs-attr">parameters:</span>
+    <span class="hljs-attr">database_driver:</span>   <span class="hljs-string">pdo_mysql</span>
+</code></pre>
+    </div>
+</div>
+<p>And configuration blocks:</p>
+<div class="configuration-block">
+    <ul class="simple">
+                    <li>
+                <em>YAML</em>
+                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/config.yml</span>
+<span class="hljs-attr">framework:</span>
+    <span class="hljs-attr">secret:</span>          <span class="hljs-string">'%secret%'</span>
+    <span class="hljs-attr">router:</span>          <span class="hljs-string">{</span> <span class="hljs-attr">resource:</span> <span class="hljs-string">'%kernel.root_dir%/config/routing.yml'</span> <span class="hljs-string">}</span>
+    <span class="hljs-comment"># ...</span>
+
+<span class="hljs-comment"># ...</span>
+</code></pre>
+    </div>
+</div>
+            </li>
+                    <li>
+                <em>XML</em>
+                <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-xml">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9
 10
 11
 12
@@ -321,155 +229,92 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 18
 19
 20</pre>
-                                        </div>
-                                    </td>
-                                    <td class="code">
-                                        <div class="highlight">
-                                            <pre class="hljs xml">
-                                                                    <span class="hljs-comment">&lt;!-- app/config/config.xml --&gt;</span>
-                                                                    <span class="hljs-meta">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
-                                                                    <span class="hljs-tag">
-                                                                        &lt;
-                                                                        <span class="hljs-name">container</span>
-                                                                        <span class="hljs-attr">xmlns</span>
-                                                                        =
-                                                                        <span class="hljs-string">"http://symfony.com/schema/dic/services"</span>
-                                                                        <span class="hljs-attr">xmlns:xsi</span>
-                                                                        =
-                                                                        <span class="hljs-string">"http://www.w3.org/2001/XMLSchema-instance"</span>
-                                                                        <span class="hljs-attr">xmlns:framework</span>
-                                                                        =
-                                                                        <span class="hljs-string">"http://symfony.com/schema/dic/symfony"</span>
-                                                                        <span class="hljs-attr">xmlns:twig</span>
-                                                                        =
-                                                                        <span class="hljs-string">"http://symfony.com/schema/dic/twig"</span>
-                                                                        <span class="hljs-attr">xsi:schemaLocation</span>
-                                                                        =
-                                                                        <span class="hljs-string">"http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd"</span>
-                                                                        &gt;
-                                                                    </span>
-                                                                    <span class="hljs-tag">
-                                                                        &lt;
-                                                                        <span class="hljs-name">framework:config</span>
-                                                                        <span class="hljs-attr">secret</span>
-                                                                        =
-                                                                        <span class="hljs-string">"%secret%"</span>
-                                                                        &gt;
-                                                                    </span>
-                                                                    <span class="hljs-tag">
-                                                                        &lt;
-                                                                        <span class="hljs-name">framework:router</span>
-                                                                        <span class="hljs-attr">resource</span>
-                                                                        =
-                                                                        <span class="hljs-string">"%kernel.root_dir%/config/routing.xml"</span>
-                                                                        /&gt;
-                                                                    </span>
-                                                                    <span class="hljs-comment">&lt;!-- ... --&gt;</span>
-                                                                    <span class="hljs-tag">
-                                                                        &lt;/
-                                                                        <span class="hljs-name">framework:config</span>
-                                                                        &gt;
-                                                                    </span>
-                                                                    <span class="hljs-comment">&lt;!-- ... --&gt;</span>
-                                                                    <span class="hljs-tag">
-                                                                        &lt;/
-                                                                        <span class="hljs-name">container</span>
-                                                                        &gt;
-                                                                    </span>
-                                                                </pre>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <em>PHP</em>
-                    <div translate="no" class="notranslate literal-block loc-2">
-                        <div class="highlight-php">
-                            <table class="highlighttable">
-                                <tr>
-                                    <td class="linenos">
-                                        <div class="linenodiv">
-                                            <pre> 1 2 3 4 5 6 7 8 9
-10</pre>
-                                        </div>
-                                    </td>
-                                    <td class="code">
-                                        <div class="highlight">
-                                            <pre class="hljs php">
-                                                                    <span class="hljs-comment">// app/config/config.php</span>
-                                                                    <span class="hljs-variable">
-                                                                        <span class="hljs-variable-other-marker">$</span>
-                                                                        container
-                                                                    </span>
-                                                                    <span class="hljs-operator">-&gt;</span>
-                                                                    loadFromExtension(
-                                                                    <span class="hljs-string">'framework'</span>
-                                                                    , 
-                                                                    <span class="hljs-keyword">array</span>
-                                                                    ( 
-                                                                    <span class="hljs-string">'secret'</span>
-                                                                    =&gt; 
-                                                                    <span class="hljs-string">'%secret%'</span>
-                                                                    , 
-                                                                    <span class="hljs-string">'router'</span>
-                                                                    =&gt; 
-                                                                    <span class="hljs-keyword">array</span>
-                                                                    ( 
-                                                                    <span class="hljs-string">'resource'</span>
-                                                                    =&gt; 
-                                                                    <span class="hljs-string">'%kernel.root_dir%/config/routing.php'</span>
-                                                                    , ), 
-                                                                    <span class="hljs-comment">// ...</span>
-                                                                    )); 
-                                                                    <span class="hljs-comment">// ...</span>
-                                                                </pre>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </table>
-                        </div>
-                    </div>
-                </li>
-            </ul>
-        </div>
+        <pre class="codeblock-code"><code><span class="hljs-comment">&lt;!-- app/config/config.xml --&gt;</span>
+<span class="hljs-meta">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">container</span> <span class="hljs-attr">xmlns</span>=<span class="hljs-string">"http://symfony.com/schema/dic/services"</span>
+    <span class="hljs-attr">xmlns:xsi</span>=<span class="hljs-string">"http://www.w3.org/2001/XMLSchema-instance"</span>
+    <span class="hljs-attr">xmlns:framework</span>=<span class="hljs-string">"http://symfony.com/schema/dic/symfony"</span>
+    <span class="hljs-attr">xmlns:twig</span>=<span class="hljs-string">"http://symfony.com/schema/dic/twig"</span>
+    <span class="hljs-attr">xsi:schemaLocation</span>=<span class="hljs-string">"http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony
+        http://symfony.com/schema/dic/symfony/symfony-1.0.xsd
+        http://symfony.com/schema/dic/twig
+        http://symfony.com/schema/dic/twig/twig-1.0.xsd"</span>&gt;</span>
+
+    <span class="hljs-tag">&lt;<span class="hljs-name">framework:config</span> <span class="hljs-attr">secret</span>=<span class="hljs-string">"%secret%"</span>&gt;</span>
+        <span class="hljs-tag">&lt;<span class="hljs-name">framework:router</span> <span class="hljs-attr">resource</span>=<span class="hljs-string">"%kernel.root_dir%/config/routing.xml"</span> /&gt;</span>
+        <span class="hljs-comment">&lt;!-- ... --&gt;</span>
+    <span class="hljs-tag">&lt;/<span class="hljs-name">framework:config</span>&gt;</span>
+
+    <span class="hljs-comment">&lt;!-- ... --&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">container</span>&gt;</span>
+</code></pre>
     </div>
 </div>
-<div class="section">
-    <h2 id="field-variables">
-        <a class="headerlink" href="#field-variables" title="Permalink to this headline">Field Variables</a>
-    </h2>
-    <table>
-        <thead>
-        <tr>
-            <th>Variable</th>
-            <th>Type</th>
-            <th>Usage</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-            <td>widget</td>
-            <td><code translate="no" class="notranslate">mixed</code></td>
-            <td>The value of the <code translate="no" class="notranslate">widget</code> option</td>
-        </tr>
-        <tr>
-            <td>type</td>
-            <td><code translate="no" class="notranslate">string</code></td>
-            <td>Multiple lines of text here, to show
-that off</td>
-        </tr>
-        </tbody>
-    </table>
+            </li>
+                    <li>
+                <em>PHP</em>
+                <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php">
+    <div class="codeblock-scroll">
+        <pre class="codeblock-lines">1
+2
+3
+4
+5
+6
+7
+8
+9
+10</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">// app/config/config.php</span>
+<span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>container</span><span class="hljs-operator">-&gt;</span>loadFromExtension(<span class="hljs-string">'framework'</span>, <span class="hljs-keyword">array</span>(
+    <span class="hljs-string">'secret'</span> =&gt; <span class="hljs-string">'%secret%'</span>,
+    <span class="hljs-string">'router'</span> =&gt; <span class="hljs-keyword">array</span>(
+        <span class="hljs-string">'resource'</span> =&gt; <span class="hljs-string">'%kernel.root_dir%/config/routing.php'</span>,
+    ),
+    <span class="hljs-comment">// ...</span>
+));
+
+<span class="hljs-comment">// ...</span>
+</code></pre>
+    </div>
+</div>
+            </li>
+            </ul></div>
+</div>
 </div>
 <div class="section">
-    <h2 id="url-checker-errors">
-        <a class="headerlink" href="#url-checker-errors" title="Permalink to this headline">Url checker errors</a>
-    </h2>
-    <p>This is a <a href="https://symfony.com/404" class="reference external">404 error</a>.
+<h2 id="field-variables"><a class="headerlink" href="#field-variables" title="Permalink to this headline">Field Variables</a></h2>
+<table>
+            <thead>
+                            <tr>
+                                            <th>Variable</th>
+                                            <th>Type</th>
+                                            <th>Usage</th>
+                                    </tr>
+                    </thead>
+    
+    <tbody>
+                    <tr>
+                                    <td>widget</td>
+                                    <td><code translate="no" class="notranslate">mixed</code></td>
+                                    <td>The value of the <code translate="no" class="notranslate">widget</code> option</td>
+                            </tr>
+                    <tr>
+                                    <td>type</td>
+                                    <td><code translate="no" class="notranslate">string</code></td>
+                                    <td>Multiple lines of text here, to show
+that off</td>
+                            </tr>
+            </tbody>
+</table>
+</div>
+<div class="section">
+<h2 id="url-checker-errors"><a class="headerlink" href="#url-checker-errors" title="Permalink to this headline">Url checker errors</a></h2>
+<p>This is a <a href="https://symfony.com/404" class="reference external">404 error</a>.
 And here is an invalid url <a href="http://invalid-url" class="reference external">invalid-url</a>.</p>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/main/form/form_type.html
+++ b/tests/fixtures/expected/main/form/form_type.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
-    <h1 id="formtype-documentation">
-        <a class="headerlink" href="#formtype-documentation" title="Permalink to this headline">FormType Documentation</a>
-    </h1>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="formtype-documentation"><a class="headerlink" href="#formtype-documentation" title="Permalink to this headline">FormType Documentation</a></h1>
 <span id="internal-reference"></span>
 <img src="../_images/symfony-logo.png" />
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/main/index.html
+++ b/tests/fixtures/expected/main/index.html
@@ -1,34 +1,22 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
-    <h1 id="some-test-docs">
-        <a class="headerlink" href="#some-test-docs" title="Permalink to this headline">Some Test Docs!</a>
-    </h1>
-    <img src="_images/symfony-logo.png" />
-    <div class="toctree-wrapper">
-        <ul class="toctree toctree-level-1 toctree-length-2">
-            <li><a href="datetime.html#datetimetype-field">DateTimeType Field</a>
-                <ul class="toctree toctree-level-2 toctree-length-4">
-                    <li><a href="datetime.html#field-options">Field Options</a></li>
-                    <li><a href="datetime.html#overridden-options">Overridden Options</a></li>
-                    <li><a href="datetime.html#field-variables">Field Variables</a></li>
-                    <li><a href="datetime.html#url-checker-errors">Url checker errors</a></li>
-                </ul>
-            </li>
-            <li><a href="form/form_type.html#formtype-documentation">FormType Documentation</a></li>
-        </ul>
-    </div>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="some-test-docs"><a class="headerlink" href="#some-test-docs" title="Permalink to this headline">Some Test Docs!</a></h1>
+<img src="_images/symfony-logo.png" />
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-2"><li><a href="datetime.html#datetimetype-field">DateTimeType Field</a><ul class="toctree toctree-level-2 toctree-length-4"><li><a href="datetime.html#field-options">Field Options</a></li><li><a href="datetime.html#overridden-options">Overridden Options</a></li><li><a href="datetime.html#field-variables">Field Variables</a></li><li><a href="datetime.html#url-checker-errors">Url checker errors</a></li></ul></li><li><a href="form/form_type.html#formtype-documentation">FormType Documentation</a></li></ul></div>
 <span id="reference-forms-type-date-format"></span>
 <div class="section">
-    <h2 id="a-header">
-        <a class="headerlink" href="#a-header" title="Permalink to this headline">A header</a>
-    </h2>
-    <p>Some info...</p>
+<h2 id="a-header"><a class="headerlink" href="#a-header" title="Permalink to this headline">A header</a></h2>
+<p>Some info...</p>
 </div>
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/ref-reference/index.html
+++ b/tests/fixtures/expected/ref-reference/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
-    <h1 id="a-test-for-reference">
-        <a class="headerlink" href="#a-test-for-reference" title="Permalink to this headline">A test for reference</a>
-    </h1>
-    <p><a href="file.html#ref-test" class="reference internal">A ref test</a></p>
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
+<h1 id="a-test-for-reference"><a class="headerlink" href="#a-test-for-reference" title="Permalink to this headline">A test for reference</a></h1>
+<p><a href="file.html#ref-test" class="reference internal">A ref test</a></p>
+
 </div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/toctree/index.html
+++ b/tests/fixtures/expected/toctree/index.html
@@ -1,52 +1,21 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8" />
-</head>
-<body>
-<div class="section">
+    <head>
+        <meta charset="utf-8" />
+
+            
+    </head>
+
+    <body>
+            <div class="section">
 <h1 id="toctree"><a class="headerlink" href="#toctree" title="Permalink to this headline">Toctree</a></h1>
-<div class="toctree-wrapper">
-    <ul class="toctree toctree-level-1 toctree-length-1">
-        <li><a href="file.html#title">Title</a>
-            <ul class="toctree toctree-level-2 toctree-length-1">
-                <li><a href="file.html#sub-title">Sub title</a></li>
-            </ul>
-        </li>
-    </ul>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html#title">Title</a></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="directory/another_file.html#another-file">Another file</a></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="directory/another_file.html#another-file">Another file</a></li><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="index.html#toctree">Toctree</a></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="directory/another_file.html#another-file">Another file</a></li><li><a href="index.html#toctree">Toctree</a></li></ul></div>
+
 </div>
-<div class="toctree-wrapper">
-    <ul class="toctree toctree-level-1 toctree-length-1">
-        <li><a href="file.html#title">Title</a></li>
-    </ul>
-</div>
-<div class="toctree-wrapper">
-    <ul class="toctree toctree-level-1 toctree-length-1">
-        <li><a href="directory/another_file.html#another-file">Another file</a></li>
-    </ul>
-</div>
-<div class="toctree-wrapper">
-    <ul class="toctree toctree-level-1 toctree-length-3">
-        <li><a href="index.html#toctree">Toctree</a></li>
-        <li><a href="directory/another_file.html#another-file">Another file</a></li>
-        <li><a href="file.html#title">Title</a>
-            <ul class="toctree toctree-level-2 toctree-length-1">
-                <li><a href="file.html#sub-title">Sub title</a></li>
-            </ul>
-        </li>
-    </ul>
-</div>
-<div class="toctree-wrapper">
-    <ul class="toctree toctree-level-1 toctree-length-3">
-        <li><a href="file.html#title">Title</a>
-            <ul class="toctree toctree-level-2 toctree-length-1">
-                <li><a href="file.html#sub-title">Sub title</a></li>
-            </ul>
-        </li>
-        <li><a href="index.html#toctree">Toctree</a></li>
-        <li><a href="directory/another_file.html#another-file">Another file</a></li>
-    </ul>
-</div>
-</div>
-</body>
+
+    </body>
 </html>

--- a/tests/fixtures/expected/toctree/index.html
+++ b/tests/fixtures/expected/toctree/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
 
-            
+
     </head>
 
     <body>
@@ -12,8 +12,8 @@
 <div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li></ul></div>
 <div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="file.html#title">Title</a></li></ul></div>
 <div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-1"><li><a href="directory/another_file.html#another-file">Another file</a></li></ul></div>
-<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="directory/another_file.html#another-file">Another file</a></li><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="index.html#toctree">Toctree</a></li></ul></div>
-<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="directory/another_file.html#another-file">Another file</a></li><li><a href="index.html#toctree">Toctree</a></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="index.html#toctree">Toctree</a></li><li><a href="directory/another_file.html#another-file">Another file</a></li><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li></ul></div>
+<div class="toctree-wrapper"><ul class="toctree toctree-level-1 toctree-length-3"><li><a href="file.html#title">Title</a><ul class="toctree toctree-level-2 toctree-length-1"><li><a href="file.html#sub-title">Sub title</a></li></ul></li><li><a href="index.html#toctree">Toctree</a></li><li><a href="directory/another_file.html#another-file">Another file</a></li></ul></div>
 
 </div>
 


### PR DESCRIPTION
This updates the generated HTML for code listings or code blocks. I've been studying the way code blocks are highlighted in the best modern websites (GitHub, Stripe, etc.) and I think we should do the same. The final HTML is much less verbose, it doesn't rely on tables and the new HTML features are universally supported in browsers.

I'll update tests after rebasing when the other PR related to code is merged. Thanks!