### PR TITLE
Updated literal blocks to improve word breaking

### DIFF
--- a/src/Renderers/SpanNodeRenderer.php
+++ b/src/Renderers/SpanNodeRenderer.php
@@ -62,7 +62,21 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
         );
     }
 
-    public function isExternalUrl($url): bool
+    public function literal(string $text): string
+    {
+        // some browsers can't break long <code> properly, so we inject a
+        // `<wbr>` (word-break HTML tag) after some characters to help break those
+        // We only do this for very long <code> (4 or more \\) to not break short
+        // and common `<code> such as App\Entity\Something
+        if (substr_count($text, '\\') >= 4) {
+            // breaking before the backslask is what Firefox browser does
+            $text = str_replace('\\', '<wbr>\\', $text);
+        }
+
+        return $this->templateRenderer->render('literal.html.twig', ['text' => $text]);
+    }
+
+    private function isExternalUrl($url): bool
     {
         return u($url)->containsAny('://');
     }

--- a/src/Renderers/SpanNodeRenderer.php
+++ b/src/Renderers/SpanNodeRenderer.php
@@ -67,7 +67,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
         // some browsers can't break long <code> properly, so we inject a
         // `<wbr>` (word-break HTML tag) after some characters to help break those
         // We only do this for very long <code> (4 or more \\) to not break short
-        // and common `<code> such as App\Entity\Something
+        // and common `<code>` such as App\Entity\Something
         if (substr_count($text, '\\') >= 4) {
             // breaking before the backslask is what Firefox browser does
             $text = str_replace('\\', '<wbr>\\', $text);

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -28,5 +28,13 @@
     </div>
 </div>
 
+    <p>
+        The CRUD controller of <code translate="no" class="notranslate">App\Entity\Example</code> must implement
+the
+        <code translate="no" class="notranslate">EasyCorp<wbr>\Bundle<wbr>\EasyAdminBundle<wbr>\Contracts<wbr>\Controller<wbr>\CrudControllerInterface</code>
+        ,
+but you can also extend from the <code translate="no" class="notranslate">AbstractCrudController</code> class.
+    </p>
+
     </body>
 </html>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -126,7 +126,7 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
 </div>
 <div class="section">
 <h3 id="format"><a class="headerlink" href="#format" title="Permalink to this headline">format</a></h3>
-<p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">Symfony\Component\Form\Extension\Core\Type\DateTimeType::HTML5_FORMAT</code></p>
+<p><strong>type</strong>: <code translate="no" class="notranslate">string</code><strong>default</strong>: <code translate="no" class="notranslate">Symfony<wbr>\Component<wbr>\Form<wbr>\Extension<wbr>\Core<wbr>\Type<wbr>\DateTimeType::HTML5_FORMAT</code></p>
 <p>If the <code translate="no" class="notranslate">widget</code> option is set to <code translate="no" class="notranslate">single_text</code>, this option specifies
 the format of the input, i.e. how Symfony will interpret the given input
 as a datetime string. See <a href="http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax" class="reference external">Date/Time Format Syntax</a>.</p>

--- a/tests/fixtures/source/blocks/nodes/literal.rst
+++ b/tests/fixtures/source/blocks/nodes/literal.rst
@@ -1,4 +1,3 @@
-
 here is some php code from literal::
 
     // config/routes.php
@@ -9,3 +8,6 @@ here is some php code from literal::
             ->controller('App\Controller\CompanyController::about');
     };
 
+The CRUD controller of ``App\Entity\Example`` must implement
+the ``EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface``,
+but you can also extend from the ``AbstractCrudController`` class.


### PR DESCRIPTION
In Symfony Docs is very common to have long PHP namespaces as `<code>` elements.

Firefox is the smartest browser and can break them by the backslash:

![firefox-default](https://user-images.githubusercontent.com/73419/111628417-7b920500-87f0-11eb-924b-bee27476b6d6.png)

However, Chrome and others don't do that, so the result is large and ugly gaps in the text:

![chrome-default](https://user-images.githubusercontent.com/73419/111628469-89478a80-87f0-11eb-9159-9192686ff023.png)

This PR proposes a *trick* to add `<wbr>` tags in some cases to help browsers. These `<wbr>` are completely transparent to users and they don't appear even if you copy+paste the text.

After this PR, Chrome looks like this:

![chrome-with-wbr](https://user-images.githubusercontent.com/73419/111628584-a8deb300-87f0-11eb-8823-2fad24ad5e41.png)
