### PR TITLE
Consider "versionadded" as an admonition and improve "seealso" admonition

### DIFF
--- a/src/Directive/VersionAddedDirective.php
+++ b/src/Directive/VersionAddedDirective.php
@@ -23,12 +23,15 @@ class VersionAddedDirective extends SubDirective
     public function processSub(Parser $parser, ?Node $document, string $variable, string $data, array $options): ?Node
     {
         $wrapperDiv = $parser->renderTemplate(
-            'directives/version-added.html.twig',
+            'directives/admonition.html.twig',
             [
+                'name' => 'versionadded',
+                'text' => sprintf('New in version %s', $data),
+                'class' => $options['class'] ?? null,
                 'version' => $data,
             ]
         );
 
-        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div></div>');
+        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div>');
     }
 }

--- a/src/Templates/default/html/directives/admonition.html.twig
+++ b/src/Templates/default/html/directives/admonition.html.twig
@@ -9,6 +9,10 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
         {% elseif name in ['caution', 'danger', 'error'] %}
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+        {% elseif name in ['versionadded'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path></svg>
+        {% elseif name in ['seealso'] %}
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
         {% endif %}
         {{ text }}
     </p>

--- a/tests/fixtures/expected/blocks/directives/seealso.html
+++ b/tests/fixtures/expected/blocks/directives/seealso.html
@@ -8,10 +8,13 @@
 
     <body>
             <div class="admonition admonition-seealso ">
-    <p class="admonition-title">
-                See also
-    </p><p>Also check out the homepage</p>
-</div>
-
-    </body>
-</html>
+             <p class="admonition-title">
+                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
+                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                     </svg>
+                     See also
+                 </p>
+                 <p>Also check out the homepage</p>
+             </div>
+         </body>
+     </html>

--- a/tests/fixtures/expected/blocks/directives/versionadded.html
+++ b/tests/fixtures/expected/blocks/directives/versionadded.html
@@ -7,8 +7,15 @@
     </head>
 
     <body>
-            <div class="versionadded"><div><span class="versionmodified">New in version 4.1: </span><p>This option was introduced in Symfony 2.6 and replaces another option, which is available prior to 2.6.</p>
-</div></div>
+        <div class="admonition admonition-versionadded ">
+             <p class="admonition-title">
+                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
+                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path>
+                 </svg>
+                 New in version 4.1
+             </p>
+             <p>This option was introduced in Symfony 2.6 and replaces another option, which is available prior to 2.6.</p>
+         </div>
 
     </body>
 </html>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -85,10 +85,15 @@ Or a PHP method! <a href="https://secure.php.net/manual/en/locale.getdefault.php
 </div>
 <div class="section">
 <h3 id="placeholder"><a class="headerlink" href="#placeholder" title="Permalink to this headline">placeholder</a></h3>
-<div class="versionadded"><div><span class="versionmodified">New in version 2.6: </span><p>The <code translate="no" class="notranslate">placeholder</code> option was introduced in Symfony 2.6 and replaces
+<div class="admonition admonition-versionadded ">
+<p class="admonition-title">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"></path>
+    </svg>
+New in version 2.6</p>
+<p>The <code translate="no" class="notranslate">placeholder</code> option was introduced in Symfony 2.6 and replaces
 <code translate="no" class="notranslate">empty_value</code>, which is available prior to 2.6.
-<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>
-</div></div>
+<a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p></div>
 <p><strong>type</strong>: <code translate="no" class="notranslate">string</code> | <code translate="no" class="notranslate">array</code></p>
 <p>If your widget option is set to <code translate="no" class="notranslate">choice</code>, then this field will be represented
 as a series of <code translate="no" class="notranslate">select</code> boxes. When the placeholder value is a string,
@@ -110,6 +115,9 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
 </div>
 <div class="admonition admonition-seealso ">
     <p class="admonition-title">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor">
+         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+         </svg>
                 See also
     </p><p>Also check out the homepage - <a href="index.html" class="reference internal">Some Test Docs!</a>.
 <a href="form/form_type.html#internal-reference" class="reference internal">FormType Documentation</a></p>


### PR DESCRIPTION
This PR makes two changes:

* Handles/renders "versionadded" directives as adominitions, to minimize the changes needed when publishing contents.
* It adds an icon to "seealso" admonition to better match the style of other admonitions.

In practice it looks like this:

![image](https://user-images.githubusercontent.com/73419/111813494-8ffdfc80-88d9-11eb-8d9d-9728936c4c09.png)
