### PR TITLE
Fix links in generated JSON

### DIFF
--- a/src/Generator/JsonGenerator.php
+++ b/src/Generator/JsonGenerator.php
@@ -141,12 +141,7 @@ class JsonGenerator
             return null;
         }
 
-        $meta = $this->getMetaEntry($nextFileName);
-
-        return [
-            'title' => $meta->getTitle(),
-            'link' => $meta->getUrl(),
-        ];
+        return $this->makeRelativeLink($parserFilename, $nextFileName);
     }
 
     private function determinePrev(string $parserFilename, array $flattenedTocTree): ?array
@@ -167,12 +162,7 @@ class JsonGenerator
             return null;
         }
 
-        $meta = $this->getMetaEntry($previousFileName);
-
-        return [
-            'title' => $meta->getTitle(),
-            'link' => $meta->getUrl(),
-        ];
+        return $this->makeRelativeLink($parserFilename, $previousFileName);
     }
 
     private function getMetaEntry(string $parserFilename, bool $throwOnMissing = false): ?MetaEntry
@@ -266,7 +256,7 @@ class JsonGenerator
                 return $parents;
             }
 
-            $subParents = $this->determineParents($parserFilename, $tocTree, $parents + [$filename]);
+            $subParents = $this->determineParents($parserFilename, $tocTree, $parents + [$this->makeRelativeLink($parserFilename, $filename)]);
 
             if (null !== $subParents) {
                 // the item WAS found and the parents were returned
@@ -276,5 +266,15 @@ class JsonGenerator
 
         // item was not found
         return null;
+    }
+
+    private function makeRelativeLink(string $currentFilename, string $filename): array
+    {
+        $meta = $this->getMetaEntry($filename);
+
+        return [
+            'title' => $meta->getTitle(),
+            'link' => str_repeat('../', substr_count($currentFilename, '/')).$meta->getUrl(),
+        ];
     }
 }

--- a/tests/JsonIntegrationTest.php
+++ b/tests/JsonIntegrationTest.php
@@ -80,7 +80,12 @@ class JsonIntegrationTest extends AbstractIntegrationTest
         yield 'crud' => [
            'file' => 'crud',
            'data' => [
-               'parents' => ['design'],
+               'parents' => [
+                    [
+                        'title' => 'Design',
+                        'link' => 'design.html',
+                    ],
+                ],
                'prev' => [
                    'title' => 'Design',
                    'link' => 'design.html',
@@ -96,14 +101,19 @@ class JsonIntegrationTest extends AbstractIntegrationTest
         yield 'design/sub-page' => [
             'file' => 'design/sub-page',
             'data' => [
-                'parents' => ['design'],
+                'parents' => [
+                    [
+                        'title' => 'Design',
+                        'link' => '../design.html',
+                    ],
+                ],
                 'prev' => [
                     'title' => 'CRUD',
-                    'link' => 'crud.html',
+                    'link' => '../crud.html',
                 ],
                 'next' => [
                     'title' => 'Fields',
-                    'link' => 'fields.html',
+                    'link' => '../fields.html',
                 ],
                 'title' => 'Design Sub-Page',
             ]


### PR DESCRIPTION
* Links are relative to the current file
* `parents` is an array of links like the ones for `prev` and `next`