### PR TITLE
Tweaked the configuration block directive

### DIFF
--- a/src/Templates/default/html/directives/configuration-block.html.twig
+++ b/src/Templates/default/html/directives/configuration-block.html.twig
@@ -1,9 +1,14 @@
 <div class="configuration-block">
-    <ul class="simple">
+    <ul class="configuration-tabs">
         {% for block in blocks %}
             <li>
-                <em>{{ block.language }}</em>
-                {{ block.code|raw }}
+                <a href="#" {{ loop.first ? 'data-active' }} data-language="{{ block.language }}">{{ block.language }}</a>
             </li>
         {% endfor %}
     </ul>
+
+    {% for block in blocks %}
+        <div class="configuration-codeblock" data-language="{{ block.language }}" style="{{ not loop.first ? 'display: none' }}">
+            {{ block.code|raw }}
+        </div>
+    {% endfor %}

--- a/src/Templates/default/html/directives/configuration-block.html.twig
+++ b/src/Templates/default/html/directives/configuration-block.html.twig
@@ -1,8 +1,8 @@
 <div class="configuration-block">
     <ul class="configuration-tabs">
         {% for block in blocks %}
-            <li>
-                <a href="#" {{ loop.first ? 'data-active' }} data-language="{{ block.language }}">{{ block.language }}</a>
+            <li data-language="{{ block.language }}" {{ loop.first ? 'data-active="true"' }}>
+                <a href="#">{{ block.language }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/src/Templates/default/html/directives/configuration-block.html.twig
+++ b/src/Templates/default/html/directives/configuration-block.html.twig
@@ -2,7 +2,7 @@
     <ul class="configuration-tabs">
         {% for block in blocks %}
             <li data-language="{{ block.language }}" {{ loop.first ? 'data-active="true"' }}>
-                <a href="#">{{ block.language }}</a>
+                <span>{{ block.language }}</span>
             </li>
         {% endfor %}
     </ul>

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -1,7 +1,7 @@
 <div class="configuration-block">
     <ul class="configuration-tabs">
-        <li> <a href="#" data-active data-language="YAML">YAML</a> </li>
-        <li> <a href="#" data-language="PHP">PHP</a> </li>
+        <li data-language="YAML" data-active="true"> <a href="#">YAML</a> </li>
+        <li data-language="PHP" > <a href="#">PHP</a> </li>
     </ul>
     <div class="configuration-codeblock" data-language="YAML" style="">
         <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -1,7 +1,7 @@
 <div class="configuration-block">
     <ul class="configuration-tabs">
-        <li data-language="YAML" data-active="true"> <a href="#">YAML</a> </li>
-        <li data-language="PHP" > <a href="#">PHP</a> </li>
+        <li data-language="YAML" data-active="true"> <span>YAML</span> </li>
+        <li data-language="PHP" > <span>PHP</span> </li>
     </ul>
     <div class="configuration-codeblock" data-language="YAML" style="">
         <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">

--- a/tests/fixtures/expected/blocks/directives/configuration-block.html
+++ b/tests/fixtures/expected/blocks/directives/configuration-block.html
@@ -1,23 +1,22 @@
 <div class="configuration-block">
-    <ul class="simple">
-                    <li>
-                <em>YAML</em>
-                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
-    <div class="codeblock-scroll">
-        <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/services.yml</span>
-</code></pre>
+    <ul class="configuration-tabs">
+        <li> <a href="#" data-active data-language="YAML">YAML</a> </li>
+        <li> <a href="#" data-language="PHP">PHP</a> </li>
+    </ul>
+    <div class="configuration-codeblock" data-language="YAML" style="">
+        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+            <div class="codeblock-scroll">
+                <pre class="codeblock-lines">1</pre>
+                <pre class="codeblock-code"><code><span class="hljs-comment"># app/config/services.yml</span></code></pre>
+            </div>
+        </div>
+    </div>
+    <div class="configuration-codeblock" data-language="PHP" style="display: none">
+        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
+            <div class="codeblock-scroll">
+                <pre class="codeblock-lines">1</pre>
+                <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span></code></pre>
+            </div>
+        </div>
     </div>
 </div>
-            </li>
-                    <li>
-                <em>PHP</em>
-                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-php">
-    <div class="codeblock-scroll">
-        <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code><span class="hljs-comment">// config/routes.php</span>
-</code></pre>
-    </div>
-</div>
-            </li>
-            </ul></div>

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -191,9 +191,9 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 <p>And configuration blocks:</p>
 <div class="configuration-block">
     <ul class="configuration-tabs">
-        <li> <a href="#" data-active data-language="YAML">YAML</a> </li>
-        <li> <a href="#" data-language="XML">XML</a> </li>
-        <li> <a href="#" data-language="PHP">PHP</a> </li>
+        <li data-language="YAML" data-active="true"> <a href="#">YAML</a> </li>
+        <li data-language="XML" > <a href="#">XML</a> </li>
+        <li data-language="PHP" > <a href="#">PHP</a> </li>
     </ul>
     <div class="configuration-codeblock" data-language="YAML" style="">
         <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -191,9 +191,9 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 <p>And configuration blocks:</p>
 <div class="configuration-block">
     <ul class="configuration-tabs">
-        <li data-language="YAML" data-active="true"> <a href="#">YAML</a> </li>
-        <li data-language="XML" > <a href="#">XML</a> </li>
-        <li data-language="PHP" > <a href="#">PHP</a> </li>
+        <li data-language="YAML" data-active="true"> <span>YAML</span> </li>
+        <li data-language="XML" > <span>XML</span> </li>
+        <li data-language="PHP" > <span>PHP</span> </li>
     </ul>
     <div class="configuration-codeblock" data-language="YAML" style="">
         <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -190,10 +190,13 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </div>
 <p>And configuration blocks:</p>
 <div class="configuration-block">
-    <ul class="simple">
-                    <li>
-                <em>YAML</em>
-                <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
+    <ul class="configuration-tabs">
+        <li> <a href="#" data-active data-language="YAML">YAML</a> </li>
+        <li> <a href="#" data-language="XML">XML</a> </li>
+        <li> <a href="#" data-language="PHP">PHP</a> </li>
+    </ul>
+    <div class="configuration-codeblock" data-language="YAML" style="">
+        <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-yaml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -212,10 +215,9 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </code></pre>
     </div>
 </div>
-            </li>
-                    <li>
-                <em>XML</em>
-                <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-xml">
+        </div>
+        <div class="configuration-codeblock" data-language="XML" style="display: none">
+            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-xml">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -260,10 +262,9 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </code></pre>
     </div>
 </div>
-            </li>
-                    <li>
-                <em>PHP</em>
-                <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php">
+        </div>
+        <div class="configuration-codeblock" data-language="PHP" style="display: none">
+            <div translate="no" class="notranslate codeblock codeblock-loc-2 codeblock-php">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
 2
@@ -288,8 +289,8 @@ with the <a href="datetime.html#date-widget" class="reference internal">date_wid
 </code></pre>
     </div>
 </div>
-            </li>
-            </ul></div>
+        </div>
+    </div>
 </div>
 </div>
 <div class="section">


### PR DESCRIPTION
Configuration blocks weren't styled yet in the new doc builder, so I did that and to make CSS and JS code much easier, I propose this tweaks in the generated HTML code for them.