### PR TITLE
Fixed the handling of custom image prefix

### DIFF
--- a/src/BuildConfig.php
+++ b/src/BuildConfig.php
@@ -37,7 +37,7 @@ class BuildConfig
         $this->theme = Configuration::THEME_DEFAULT;
         $this->symfonyVersion = '4.4';
         $this->excludedPaths = [];
-        $this->imagesPublicPrefix = '/_images';
+        $this->imagesPublicPrefix = '';
     }
 
     public function createFileFinder(): Finder

--- a/src/Listener/CopyImagesListener.php
+++ b/src/Listener/CopyImagesListener.php
@@ -53,7 +53,11 @@ class CopyImagesListener
         $newAbsoluteFilePath = $this->buildConfig->getImagesDir().'/'.$fileInfo->getFilename();
         $fs->copy($sourceImage, $newAbsoluteFilePath, true);
 
-        $newUrlPath = $this->buildConfig->getImagesPublicPrefix().'/'.$fileInfo->getFilename();
-        $node->setValue($node->getEnvironment()->relativeUrl($newUrlPath));
+        if ('' === $this->buildConfig->getImagesPublicPrefix()) {
+            $newUrlPath = $node->getEnvironment()->relativeUrl('_images/'.$fileInfo->getFilename());
+        } else {
+            $newUrlPath = $this->buildConfig->getImagesPublicPrefix().'/'.$fileInfo->getFilename();
+        }
+        $node->setValue($newUrlPath);
     }
 }

--- a/tests/Command/BuildDocsCommandTest.php
+++ b/tests/Command/BuildDocsCommandTest.php
@@ -90,6 +90,30 @@ class BuildDocsCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Build complete', $output);
     }
 
+    public function testBuildDocsWithCustomImagePrefix()
+    {
+        $buildConfig = $this->createBuildConfig();
+        $buildConfig->setImagesPublicPrefix('/some/custom/prefix-for-images');
+        $outputDir = __DIR__.'/../_output';
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($outputDir);
+        $filesystem->mkdir($outputDir);
+
+        $output = $this->executeCommand(
+            $buildConfig,
+            [
+                'source-dir' => __DIR__.'/../fixtures/source/main',
+                'output-dir' => $outputDir,
+            ]
+        );
+
+        $this->assertStringContainsString('[OK] Build complete', $output);
+
+        $generatedHtml = file_get_contents($outputDir.'/index.html');
+        $this->assertStringContainsString('/some/custom/prefix-for-images/symfony-logo.png', $generatedHtml);
+    }
+
     private function executeCommand(BuildConfig $buildConfig, array $input): string
     {
         $input['--no-theme'] = true;

--- a/tests/fixtures/expected/main/form/form_type.html
+++ b/tests/fixtures/expected/main/form/form_type.html
@@ -3,14 +3,14 @@
     <head>
         <meta charset="utf-8" />
 
-            
+
     </head>
 
     <body>
             <div class="section">
 <h1 id="formtype-documentation"><a class="headerlink" href="#formtype-documentation" title="Permalink to this headline">FormType Documentation</a></h1>
 <span id="internal-reference"></span>
-<img src="../_images/symfony-logo.png" />
+<img src="_images/symfony-logo.png" />
 </div>
 
     </body>


### PR DESCRIPTION
I introduced some issues when refactoring this. The new proposed logic is:

* If you provide a custom "image prefix", then the generated image URL is `<your prefix> + / + <image relative path>` (we don't change that URL to a relative one to avoid issues ... we use your provided prefix "as is")
* If you don't provide this custom "image prefix", we consider that images are stored in `<output dir>/_images/` and calculate image URLs as relative URLs.