### PR TITLE
Made the counting of code lines more robust

### DIFF
--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -79,8 +79,9 @@ class CodeNodeRenderer implements NodeRenderer
             $highlightedCode = preg_replace('/^C:\\\&gt;/m', '<span class="hljs-prompt">C:\&gt;</span>', $highlightedCode);
         }
 
+        $highlightedCode = trim($highlightedCode);
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));
-        $lines = implode("\n", range(1, $numOfLines - 1));
+        $lines = implode("\n", range(1, $numOfLines));
 
         return $this->templateRenderer->render(
             'code.html.twig',

--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -53,7 +53,7 @@ class CodeNodeRenderer implements NodeRenderer
 
     public function render(): string
     {
-        $code = $this->codeNode->getValue();
+        $code = trim($this->codeNode->getValue());
         if ($this->codeNode->isRaw()) {
             return $code;
         }
@@ -79,7 +79,6 @@ class CodeNodeRenderer implements NodeRenderer
             $highlightedCode = preg_replace('/^C:\\\&gt;/m', '<span class="hljs-prompt">C:\&gt;</span>', $highlightedCode);
         }
 
-        $highlightedCode = trim($highlightedCode);
         $numOfLines = \count(preg_split('/\r\n|\r|\n/', $highlightedCode));
         $lines = implode("\n", range(1, $numOfLines));
 

--- a/tests/fixtures/expected/blocks/code-blocks/bash.html
+++ b/tests/fixtures/expected/blocks/code-blocks/bash.html
@@ -1,7 +1,6 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-bash">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code>git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git
-</code></pre>
+        <pre class="codeblock-code"><code>git <span class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -1,7 +1,8 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html+twig codeblock-twig">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
-2</pre>
+2
+3</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
 <span class="hljs-comment">&lt;!-- some code --&gt;</span>
 </span></code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/html-twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/html-twig.html
@@ -1,8 +1,7 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-html+twig codeblock-twig">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1
-2
-3</pre>
+2</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
 <span class="hljs-comment">&lt;!-- some code --&gt;</span>
 </span></code></pre>

--- a/tests/fixtures/expected/blocks/code-blocks/ini.html
+++ b/tests/fixtures/expected/blocks/code-blocks/ini.html
@@ -1,7 +1,6 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-ini">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code><span class="hljs-attr">fetch</span> = +refs/notes/*:refs/notes/*
-</code></pre>
+        <pre class="codeblock-code"><code><span class="hljs-attr">fetch</span> = +refs/notes/*:refs/notes/*</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php-annotations.html
@@ -27,7 +27,6 @@
      * )
      */</span>
     <span class="hljs-keyword">protected</span> <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>bankAccountNumber</span>;
-}
-</code></pre>
+}</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/php.html
+++ b/tests/fixtures/expected/blocks/code-blocks/php.html
@@ -13,7 +13,6 @@
 <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>{
     <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>])
         <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
-};
-</code></pre>
+};</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/terminal.html
+++ b/tests/fixtures/expected/blocks/code-blocks/terminal.html
@@ -2,8 +2,7 @@
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
         <pre class="codeblock-code"><code>git <span
-            class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git
-</code></pre>
+            class="hljs-built_in">clone</span> git@github.com:symfony/symfony.git</code></pre>
     </div>
 </div>
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-terminal codeblock-bash">

--- a/tests/fixtures/expected/blocks/code-blocks/text.html
+++ b/tests/fixtures/expected/blocks/code-blocks/text.html
@@ -1,7 +1,6 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-text">
     <div class="codeblock-scroll">
         <pre class="codeblock-lines">1</pre>
-        <pre class="codeblock-code"><code>some text
-</code></pre>
+        <pre class="codeblock-code"><code>some text</code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -1,8 +1,6 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-twig">
     <div class="codeblock-scroll">
-        <pre class="codeblock-lines">1
-2</pre>
-        <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
-</span></code></pre>
+        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span></code></pre>
     </div>
 </div>

--- a/tests/fixtures/expected/blocks/code-blocks/twig.html
+++ b/tests/fixtures/expected/blocks/code-blocks/twig.html
@@ -1,6 +1,7 @@
 <div translate="no" class="notranslate codeblock codeblock-loc-1 codeblock-twig">
     <div class="codeblock-scroll">
-        <pre class="codeblock-lines">1</pre>
+        <pre class="codeblock-lines">1
+2</pre>
         <pre class="codeblock-code"><code><span class="hljs-comment">{# some code #}</span><span class="xml">
 </span></code></pre>
     </div>

--- a/tests/fixtures/expected/blocks/nodes/literal.html
+++ b/tests/fixtures/expected/blocks/nodes/literal.html
@@ -14,8 +14,7 @@
 <span class="hljs-keyword">return</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(RoutingConfigurator <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span>)</span> </span>{
     <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>routes</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'about_us'</span>, [<span class="hljs-string">'nl'</span> =&gt; <span class="hljs-string">'/over-ons'</span>, <span class="hljs-string">'en'</span> =&gt; <span class="hljs-string">'/about-us'</span>])
         <span class="hljs-operator">-&gt;</span>controller(<span class="hljs-string">'App\Controller\CompanyController::about'</span>);
-};
-</code></pre>
+};</code></pre>
     </div>
 </div>
 <p>The CRUD controller of <code translate="no" class="notranslate">App\Entity\Example</code> must implement

--- a/tests/fixtures/expected/main/datetime.html
+++ b/tests/fixtures/expected/main/datetime.html
@@ -109,8 +109,7 @@ it will be used as the <strong>blank value</strong> of all select boxes:</p>
 
 <span class="hljs-variable"><span class="hljs-variable-other-marker">$</span>builder</span><span class="hljs-operator">-&gt;</span>add(<span class="hljs-string">'startDateTime'</span>, DateTimeType<span class="hljs-operator">::</span>class, <span class="hljs-keyword">array</span>(
     <span class="hljs-string">'placeholder'</span> =&gt; <span class="hljs-string">'Select a value'</span>,
-));
-</code></pre>
+));</code></pre>
     </div>
 </div>
 <div class="admonition admonition-seealso ">


### PR DESCRIPTION
I saw some issues in the counting of lines in some generated docs ... so this PR tries to make things more robust.

As you can see in tests, we remove a trailing new line in some code blocks. This is correct, because new lines inside `<pre>` are significant. So, this is a bug fix in those cases.

**Update**: the following error was fixed thanks to Christophe's suggestion. Thanks!

~However, there's a problem with these tests:~

* ~`tests/fixtures/expected/blocks/code-blocks/html-twig.html`~
* ~`tests/fixtures/expected/blocks/code-blocks/twig.html`~

~I had to update those tests to fix them, but this is wrong. The extra line added to the generated HTML is wrong. I can't see why this happens. Can anyone help me? Thanks!~