### PR TITLE
refacto: don't extend from parser

### DIFF
--- a/src/Directive/RstClassDirective.php
+++ b/src/Directive/RstClassDirective.php
@@ -2,13 +2,41 @@
 
 namespace SymfonyDocsBuilder\Directive;
 
+use Doctrine\RST\Directives\SubDirective;
 use Doctrine\RST\HTML\Directives\ClassDirective;
+use Doctrine\RST\Nodes\Node;
+use Doctrine\RST\Parser;
 
 /**
  * Allows you to add custom classes to the next directive.
  */
-class RstClassDirective extends ClassDirective
+class RstClassDirective extends SubDirective
 {
+    private $classDirective;
+
+    public function __construct(ClassDirective $classDirective)
+    {
+        $this->classDirective = $classDirective;
+    }
+
+    /**
+     * @param string[] $options
+     */
+    public function processSub(
+        Parser $parser,
+        ?Node $document,
+        string $variable,
+        string $data,
+        array $options
+    ): ?Node {
+        return $this->classDirective->processSub($parser, $document, $variable, $data, $options);
+    }
+
+    public function appliesToNonBlockContent(): bool
+    {
+        return $this->classDirective->appliesToNonBlockContent();
+    }
+
     public function getName() : string
     {
         return 'rst-class';

--- a/src/KernelFactory.php
+++ b/src/KernelFactory.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SymfonyDocsBuilder;
 
 use Doctrine\RST\Configuration as RSTParserConfiguration;
+use Doctrine\RST\HTML\Directives\ClassDirective;
 use Doctrine\RST\Kernel;
 use SymfonyDocsBuilder\CI\UrlChecker;
 use SymfonyDocsBuilder\Directive as SymfonyDirectives;
@@ -80,7 +81,7 @@ final class KernelFactory
             new SymfonyDirectives\IndexDirective(),
             new SymfonyDirectives\RoleDirective(),
             new SymfonyDirectives\NoteDirective(),
-            new SymfonyDirectives\RstClassDirective(),
+            new SymfonyDirectives\RstClassDirective(new ClassDirective()),
             new SymfonyDirectives\SeeAlsoDirective(),
             new SymfonyDirectives\SidebarDirective(),
             new SymfonyDirectives\TipDirective(),

--- a/src/Renderers/CodeNodeRenderer.php
+++ b/src/Renderers/CodeNodeRenderer.php
@@ -15,7 +15,6 @@ use Doctrine\RST\Nodes\CodeNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 use Highlight\Highlighter;
-use function Symfony\Component\String\u;
 
 class CodeNodeRenderer implements NodeRenderer
 {

--- a/src/SymfonyHTMLFormat.php
+++ b/src/SymfonyHTMLFormat.php
@@ -18,6 +18,7 @@ use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
 use SymfonyDocsBuilder\CI\UrlChecker;
+use Doctrine\RST\HTML\Renderers\SpanNodeRenderer as BaseSpanNodeRenderer;
 
 /**
  * Class SymfonyHTMLFormat.
@@ -67,7 +68,7 @@ final class SymfonyHTMLFormat implements Format
                 return new Renderers\SpanNodeRenderer(
                     $node->getEnvironment(),
                     $node,
-                    $this->templateRenderer,
+                    new BaseSpanNodeRenderer($node->getEnvironment(), $node, $this->templateRenderer),
                     $this->urlChecker
                 );
             }


### PR DESCRIPTION
Hello,

this is a solution in response to this PR
https://github.com/doctrine/rst-parser/pull/144

I used composition over inheritance for both classes where we was extending parser's classes.
This way @greg0ire could cleanly close the parser's api without exceptions.
